### PR TITLE
Add support for examines

### DIFF
--- a/.changeset/chilled-ties-speak.md
+++ b/.changeset/chilled-ties-speak.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+Organize file difference utility functions

--- a/.changeset/purple-bikes-fix.md
+++ b/.changeset/purple-bikes-fix.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": minor
+---
+
+Add examine to item diff mediawiki output

--- a/.changeset/small-adults-clap.md
+++ b/.changeset/small-adults-clap.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+Fix item infobox update param

--- a/.changeset/smart-mails-brake.md
+++ b/.changeset/smart-mails-brake.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+Fix null vs non-null diff checking

--- a/src/scripts/differences/builder/builder.types.ts
+++ b/src/scripts/differences/builder/builder.types.ts
@@ -74,6 +74,7 @@ export const indexNameMap: {
       name: "Items",
       identifiers: ["name", "id"],
       fields: [
+        "examine",
         "isMembers",
         "isGrandExchangable",
         "isStackable",

--- a/src/scripts/differences/file/content/dbrows.ts
+++ b/src/scripts/differences/file/content/dbrows.ts
@@ -2,7 +2,7 @@ import _ from "underscore";
 
 import { DBRow, DBRowID, Reader } from "../../../../utils/cache2";
 import { CompareFn } from "../../differences.types";
-import { getFileDifferences } from "../file";
+import { getFileDifferences } from "../file.utils";
 
 const compareDBRows: CompareFn = ({ oldFile, newFile }) => {
   const oldEntry = oldFile

--- a/src/scripts/differences/file/content/enums.ts
+++ b/src/scripts/differences/file/content/enums.ts
@@ -2,7 +2,7 @@ import _ from "underscore";
 
 import { Enum, EnumID, Reader } from "../../../../utils/cache2";
 import { CompareFn } from "../../differences.types";
-import { getFileDifferences } from "../file";
+import { getFileDifferences } from "../file.utils";
 
 const compareEnums: CompareFn = ({ oldFile, newFile }) => {
   const oldEntry = oldFile

--- a/src/scripts/differences/file/content/items.ts
+++ b/src/scripts/differences/file/content/items.ts
@@ -4,7 +4,7 @@ import Context from "../../../../context";
 import { Item, ItemID, Reader } from "../../../../utils/cache2";
 import { buildItemInfobox } from "../../../infoboxGenernator/infoboxes/item";
 import { CompareFn } from "../../differences.types";
-import { getFileDifferences } from "../file";
+import { getFileDifferences } from "../file.utils";
 
 const compareItems: CompareFn = ({ oldFile, newFile }) => {
   const oldEntry = oldFile

--- a/src/scripts/differences/file/content/npcs.ts
+++ b/src/scripts/differences/file/content/npcs.ts
@@ -4,7 +4,7 @@ import Context from "../../../../context";
 import { NPC, NPCID, Reader } from "../../../../utils/cache2";
 import { buildNpcInfobox } from "../../../infoboxGenernator/infoboxes/npc";
 import { CompareFn } from "../../differences.types";
-import { getFileDifferences } from "../file";
+import { getFileDifferences } from "../file.utils";
 
 const compareNpcs: CompareFn = ({ oldFile, newFile }) => {
   const oldEntry = oldFile

--- a/src/scripts/differences/file/content/objects.ts
+++ b/src/scripts/differences/file/content/objects.ts
@@ -2,7 +2,7 @@ import _ from "underscore";
 
 import { Obj, ObjID, Reader } from "../../../../utils/cache2";
 import { CompareFn } from "../../differences.types";
-import { getFileDifferences } from "../file";
+import { getFileDifferences } from "../file.utils";
 
 const compareObjects: CompareFn = ({ oldFile, newFile }) => {
   const oldEntry = oldFile

--- a/src/scripts/differences/file/content/params.ts
+++ b/src/scripts/differences/file/content/params.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { Param, ParamID, Reader } from "../../../../utils/cache2";
 import { CompareFn } from "../../differences.types";
 import { getFileDifferences } from "../file.utils";

--- a/src/scripts/differences/file/content/params.ts
+++ b/src/scripts/differences/file/content/params.ts
@@ -2,7 +2,7 @@ import _ from "underscore";
 
 import { Param, ParamID, Reader } from "../../../../utils/cache2";
 import { CompareFn } from "../../differences.types";
-import { getFileDifferences } from "../file";
+import { getFileDifferences } from "../file.utils";
 
 const compareParams: CompareFn = ({ oldFile, newFile }) => {
   const oldEntry = oldFile

--- a/src/scripts/differences/file/content/struct.ts
+++ b/src/scripts/differences/file/content/struct.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { Reader, Struct, StructID } from "../../../../utils/cache2";
 import { CompareFn } from "../../differences.types";
 import { getFileDifferences } from "../file.utils";

--- a/src/scripts/differences/file/content/struct.ts
+++ b/src/scripts/differences/file/content/struct.ts
@@ -2,7 +2,7 @@ import _ from "underscore";
 
 import { Reader, Struct, StructID } from "../../../../utils/cache2";
 import { CompareFn } from "../../differences.types";
-import { getFileDifferences } from "../file";
+import { getFileDifferences } from "../file.utils";
 
 const compareStructs: CompareFn = ({ oldFile, newFile }) => {
   const oldEntry = oldFile

--- a/src/scripts/differences/file/file.ts
+++ b/src/scripts/differences/file/file.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import compareDBRows from "./content/dbrows";
 import compareEnums from "./content/enums";
 import compareItems from "./content/items";

--- a/src/scripts/differences/file/file.utils.ts
+++ b/src/scripts/differences/file/file.utils.ts
@@ -1,0 +1,129 @@
+import _ from "underscore";
+
+import { PerFileLoadable } from "../../../utils/cache2/Loadable";
+import {
+  ChangedResult,
+  ResultValue,
+  Result,
+  FileDifferences,
+} from "../differences.types";
+
+/**
+ * Retrieve the ChangedResult from two file entries
+ * @param oldEntry The old file
+ * @param newEntry The new file
+ */
+export const getChangedResult = <T extends PerFileLoadable>(
+  oldEntry: T,
+  newEntry: T
+) => {
+  const changed: ChangedResult = {};
+  Object.keys(oldEntry).forEach((key) => {
+    const oldEntryValue = oldEntry[key as keyof T] as ResultValue;
+    const newEntryValue = newEntry[key as keyof T] as ResultValue;
+    const isOldArray = Array.isArray(oldEntryValue);
+    const isNewArray = Array.isArray(newEntryValue);
+
+    if (
+      ((typeof oldEntryValue === "string" ||
+        typeof newEntryValue === "string" ||
+        typeof oldEntryValue === "number" ||
+        typeof newEntryValue === "number") &&
+        oldEntryValue !== newEntryValue) ||
+      (isOldArray &&
+        isNewArray &&
+        _.difference<any>(oldEntryValue, newEntryValue).length > 0)
+    ) {
+      changed[key] = {
+        oldValue: oldEntryValue,
+        newValue: newEntryValue,
+      };
+    } else if (isOldArray || isNewArray) {
+      changed[key] = {
+        oldValue: oldEntryValue,
+        newValue: newEntryValue,
+      };
+    } else if (oldEntryValue instanceof Map && newEntryValue instanceof Map) {
+      const oldKeys = Array.from(oldEntryValue.keys());
+      const newKeys = Array.from(newEntryValue.keys());
+
+      const addedKeys = newKeys.filter((key) => !oldKeys.includes(key));
+      const removedKeys = oldKeys.filter((key) => !newKeys.includes(key));
+      const sharedKeys = newKeys.filter((key) => oldKeys.includes(key));
+      const changedKeys = sharedKeys.filter(
+        (key) => oldEntryValue.get(key) !== newEntryValue.get(key)
+      );
+      if (
+        addedKeys.length > 0 ||
+        removedKeys.length > 0 ||
+        changedKeys.length > 0
+      )
+        changed[key] = {
+          oldValue: Object.fromEntries(oldEntryValue),
+          newValue: Object.fromEntries(newEntryValue),
+        };
+    } else if (oldEntryValue instanceof Map) {
+      changed[key] = {
+        oldValue: Object.fromEntries(oldEntryValue),
+        newValue: "",
+      };
+    } else if (newEntryValue instanceof Map) {
+      changed[key] = {
+        oldValue: "",
+        newValue: Object.fromEntries(newEntryValue),
+      };
+    }
+  });
+  if ("id" in oldEntry && "id" in newEntry) {
+    changed["id"] = {
+      oldValue: oldEntry.id as number,
+      newValue: newEntry.id as number,
+    };
+  }
+  if ("name" in oldEntry && "name" in newEntry) {
+    changed["name"] = {
+      oldValue: oldEntry.name as string,
+      newValue: newEntry.name as string,
+    };
+  }
+  return changed;
+};
+
+/**
+ * Get a Result from a file
+ * @param entry The file
+ * @returns A generated Result
+ */
+export const getFileResult = <T extends PerFileLoadable>(entry: T) => {
+  const result: Result = {};
+  Object.keys(entry).forEach((key) => {
+    const newEntryValue = entry[key as keyof T] as ResultValue;
+    result[key] =
+      newEntryValue instanceof Map
+        ? Object.fromEntries(newEntryValue)
+        : newEntryValue;
+  });
+  return result;
+};
+
+/**
+ * Retrieve the differences in a file: added, changed, and removed files.
+ * @param oldEntry The old file data
+ * @param newEntry The new file data
+ * @returns {FileDifferences}
+ */
+export const getFileDifferences = <T extends PerFileLoadable>(
+  oldEntry: T,
+  newEntry: T
+): FileDifferences => {
+  const results: FileDifferences = {};
+  if (oldEntry && newEntry) {
+    results.changed = getChangedResult(oldEntry, newEntry);
+  } else if (oldEntry) {
+    results.removed = getFileResult(oldEntry);
+  } else if (newEntry) {
+    results.added = getFileResult(newEntry);
+  }
+
+  return results;
+};

--- a/src/scripts/infoboxGenernator/infoboxes/item.ts
+++ b/src/scripts/infoboxGenernator/infoboxes/item.ts
@@ -34,7 +34,7 @@ export const buildItemInfobox = async (item: Item) => {
       release: Context.updateDate
         ? new MediaWikiDate(new Date(Context.updateDate))
         : undefined,
-      update: "Varlamore: Part One",
+      update: Context.update,
       members: item.isMembers as boolean,
       quest: "No",
       exchange: item.isGrandExchangable,


### PR DESCRIPTION
**Description**
This PR adds support for examines, simply by fixing a bug with file comparisons. Comparison differences were not being accounted for in cases where one of the two files being compared had a null value for a field.

This PR also:

- Fixes a bug with item infobox update param
- Reorganizes file difference utility functions so that they are more testable.