### PR TITLE
[#19] Correctly detect array differences

### DIFF
--- a/.changeset/lovely-cheetahs-compete.md
+++ b/.changeset/lovely-cheetahs-compete.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+Fix a bug in detecting array differences and tests for getChangedResult

--- a/src/scripts/differences/file/__tests__/file.utils.test.ts
+++ b/src/scripts/differences/file/__tests__/file.utils.test.ts
@@ -1,0 +1,166 @@
+import { NPC } from "../../../../utils/cache2";
+import { getChangedResult } from "../file.utils";
+
+describe("file utils", () => {
+  describe("getChangedResult", () => {
+    test("type: string", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            name: "test",
+          },
+          {
+            name: "test2",
+          }
+        )
+      ).toEqual({
+        name: {
+          oldValue: "test",
+          newValue: "test2",
+        },
+      });
+    });
+
+    test("type: new string", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            name: null,
+          },
+          {
+            name: "test2",
+          }
+        )
+      ).toEqual({
+        name: {
+          oldValue: null,
+          newValue: "test2",
+        },
+      });
+    });
+
+    test("type: number", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            combatLevel: 50,
+          },
+          {
+            combatLevel: 100,
+          }
+        )
+      ).toEqual({
+        combatLevel: {
+          oldValue: 50,
+          newValue: 100,
+        },
+      });
+    });
+
+    test("type: new number", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            combatLevel: null,
+          },
+          {
+            combatLevel: 100,
+          }
+        )
+      ).toEqual({
+        combatLevel: {
+          oldValue: null,
+          newValue: 100,
+        },
+      });
+    });
+
+    test("type: array added elements", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            actions: ["Talk", null, null, null, null],
+          },
+          {
+            actions: ["Talk", null, "Trade", null, null],
+          }
+        )
+      ).toEqual({
+        actions: {
+          oldValue: ["Talk", null, null, null, null],
+          newValue: ["Talk", null, "Trade", null, null],
+        },
+      });
+    });
+
+    test("type: array removed elements", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            actions: ["Talk", null, "Trade", null, null],
+          },
+          {
+            actions: ["Talk", null, null, null, null],
+          }
+        )
+      ).toEqual({
+        actions: {
+          oldValue: ["Talk", null, "Trade", null, null],
+          newValue: ["Talk", null, null, null, null],
+        },
+      });
+    });
+
+    test("type: new array", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            actions: null,
+          },
+          {
+            actions: ["Talk", null, null, null, null],
+          }
+        )
+      ).toEqual({
+        actions: {
+          oldValue: null,
+          newValue: ["Talk", null, null, null, null],
+        },
+      });
+    });
+
+    test("type: removed array", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            actions: ["Talk", null, null, null, null],
+          },
+          {
+            actions: null,
+          }
+        )
+      ).toEqual({
+        actions: {
+          oldValue: ["Talk", null, null, null, null],
+          newValue: null,
+        },
+      });
+    });
+  });
+});

--- a/src/scripts/differences/file/file.utils.ts
+++ b/src/scripts/differences/file/file.utils.ts
@@ -32,7 +32,8 @@ export const getChangedResult = <T extends PerFileLoadable>(
         oldEntryValue !== newEntryValue) ||
       (isOldArray &&
         isNewArray &&
-        _.difference<any>(oldEntryValue, newEntryValue).length > 0) ||
+        (_.difference<any>(oldEntryValue, newEntryValue).length > 0 ||
+          _.difference<any>(newEntryValue, oldEntryValue).length > 0)) ||
       (isOldArray && !isNewArray) ||
       (isNewArray && !isOldArray)
     ) {


### PR DESCRIPTION
**Description**

- Correctly detect differences in a file's array fields
- Add tests for `getChangedResult`.