### PR TITLE
Generate Combat Achievement pages

### DIFF
--- a/.changeset/wicked-hornets-laugh.md
+++ b/.changeset/wicked-hornets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": minor
+---
+
+Add support for generating Combat Achievement pages

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { parseArgs } from "node:util";
 
 import Context from "./context";
 import generateCluePages from "./scripts/clues";
+import generateCombatAchievements from "./scripts/combatAchievements";
 import differencesCache from "./scripts/differences/differences";
 import { CacheSource } from "./utils/cache";
 import { getExamines } from "./utils/examines";
@@ -92,8 +93,8 @@ const runCacheTools = async () => {
     });
   } else if (task === "clues") {
     generateCluePages(cacheSource as CacheSource, newCache, "flat");
-  } else if (task === "cas") {
-    generateCluePages(cacheSource as CacheSource, newCache, "flat");
+  } else if (task === "combat-achievements") {
+    generateCombatAchievements(cacheSource as CacheSource, newCache, "flat");
   } else {
     console.log("Invalid type argument...");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,8 +90,9 @@ const runCacheTools = async () => {
       //type: cacheFileType as CacheFileType,
       type: "flat",
     });
-  }
-  if (task === "clues") {
+  } else if (task === "clues") {
+    generateCluePages(cacheSource as CacheSource, newCache, "flat");
+  } else if (task === "cas") {
     generateCluePages(cacheSource as CacheSource, newCache, "flat");
   } else {
     console.log("Invalid type argument...");

--- a/src/scripts/clues/builder.ts
+++ b/src/scripts/clues/builder.ts
@@ -11,8 +11,9 @@ import type { InfoboxItem } from "@osrs-wiki/mediawiki-builder";
 import _ from "underscore";
 
 import { ITEM_EXAMINES } from "./clues";
-import { formatAnswers, getDirections, vowel } from "./utils";
+import { formatAnswers, getDirections } from "./utils";
 import { Item } from "../../utils/cache2";
+import { vowel } from "../../utils/string";
 
 export type Answer = {
   answer: string | number | bigint;

--- a/src/scripts/clues/utils.ts
+++ b/src/scripts/clues/utils.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from "fs/promises";
 
 import { Answer, Challenge, WieldedItems } from "./builder";
 import { CacheProvider, DBRow, Item, NPC, Obj } from "../../utils/cache2";
+import { lowerCaseFirst, vowel } from "../../utils/string";
 
 export const ITEM_PARAM_ID = 623;
 
@@ -305,20 +306,6 @@ const emotes: { [key: number]: string } = {
 
 export const getEmotePage = (emote: number): string => {
   return emotes[emote];
-};
-
-export const lowerCaseFirst = (value: string) =>
-  value.charAt(0).toLowerCase() + value.slice(1);
-
-export const vowel = (noun: string) => {
-  const vowels = ["a", "e", "i", "o", "u"];
-  const startsWith = vowels.filter((vowel) =>
-    noun
-      .toLocaleLowerCase()
-      .replaceAll(/[^a-z]/g, "")
-      .startsWith(vowel)
-  );
-  return startsWith.length > 0 ? "an" : "a";
 };
 
 export const writeClueFile = async (

--- a/src/scripts/combatAchievements/__tests__/__snapshots__/builder.test.ts.snap
+++ b/src/scripts/combatAchievements/__tests__/__snapshots__/builder.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`combatAchievementPageBuilder it should build with all fields 1`] = `
+"{{Infobox Combat Achievement
+|name = Testing
+|image = [[File:Big Monster.png|150px]]
+|members = Yes
+|description = Testing a Description
+|tier = Elite
+|monster = Big Monster
+|type = Kill Count
+|id = 1
+}}
+'''Testing''' is an [[Combat Achievements/Elite|elite combat achievement]] which requires the player to testing a Description
+
+{{Combat Achievements}}
+"
+`;

--- a/src/scripts/combatAchievements/__tests__/builder.test.ts
+++ b/src/scripts/combatAchievements/__tests__/builder.test.ts
@@ -1,0 +1,16 @@
+import combatAchievementPageBuilder from "../builder";
+
+describe("combatAchievementPageBuilder", () => {
+  test("it should build with all fields", () => {
+    const builder = combatAchievementPageBuilder({
+      id: 1,
+      title: "Testing",
+      description: "Testing a Description",
+      monster: "Big Monster",
+      type: "Kill Count",
+      tier: "Elite",
+    });
+
+    expect(builder.build()).toMatchSnapshot();
+  });
+});

--- a/src/scripts/combatAchievements/builder.ts
+++ b/src/scripts/combatAchievements/builder.ts
@@ -1,0 +1,9 @@
+import { MediaWikiBuilder } from "@osrs-wiki/mediawiki-builder";
+
+const combatAchievementPageBuilder = () => {
+  const builder = new MediaWikiBuilder();
+
+  return builder;
+};
+
+export default combatAchievementPageBuilder;

--- a/src/scripts/combatAchievements/builder.ts
+++ b/src/scripts/combatAchievements/builder.ts
@@ -1,7 +1,61 @@
-import { MediaWikiBuilder } from "@osrs-wiki/mediawiki-builder";
+import {
+  MediaWikiBreak,
+  MediaWikiBuilder,
+  MediaWikiDate,
+  MediaWikiFile,
+  MediaWikiLink,
+  MediaWikiTemplate,
+  MediaWikiText,
+} from "@osrs-wiki/mediawiki-builder";
 
-const combatAchievementPageBuilder = () => {
+import { CombatAchievement } from "./types";
+import Context from "../../context";
+import { lowerCaseFirst, vowel } from "../../utils/string";
+
+const combatAchievementPageBuilder = (combatAchievement: CombatAchievement) => {
   const builder = new MediaWikiBuilder();
+
+  const infobox = new MediaWikiTemplate("Infobox Combat Achievement");
+  infobox.add("name", combatAchievement.title);
+  infobox.add(
+    "image",
+    new MediaWikiFile(`${combatAchievement.monster}.png`, {
+      resizing: { width: 150 },
+    }).build()
+  );
+  if (Context.updateDate) {
+    infobox.add(
+      "release",
+      new MediaWikiDate(new Date(Context.updateDate)).build()
+    );
+  }
+  if (Context.update) {
+    infobox.add("update", Context.update);
+  }
+  infobox.add("members", "Yes");
+  infobox.add("description", combatAchievement.description);
+  infobox.add("tier", combatAchievement.tier);
+  infobox.add("monster", combatAchievement.monster);
+  infobox.add("type", combatAchievement.type);
+  infobox.add("id", `${combatAchievement.id}`);
+
+  builder.addContents([
+    infobox,
+    new MediaWikiText(combatAchievement.title, { bold: true }),
+    new MediaWikiText(` is ${vowel(combatAchievement.tier)} `),
+    new MediaWikiLink(
+      `Combat Achievements/${combatAchievement.tier}`,
+      `${combatAchievement.tier.toLocaleLowerCase()} combat achievement`
+    ),
+    new MediaWikiText(
+      ` which requires the player to ${lowerCaseFirst(
+        combatAchievement.description
+      )}`
+    ),
+    new MediaWikiBreak(),
+    new MediaWikiBreak(),
+    new MediaWikiTemplate("Combat Achievements"),
+  ]);
 
   return builder;
 };

--- a/src/scripts/combatAchievements/builder.ts
+++ b/src/scripts/combatAchievements/builder.ts
@@ -12,6 +12,11 @@ import { CombatAchievement } from "./types";
 import Context from "../../context";
 import { lowerCaseFirst, vowel } from "../../utils/string";
 
+/**
+ * Generate a MediaWikiBuillder from a CombatAchievement object.
+ * @param combatAchievement The CombatAchievement
+ * @returns A MediaWikiBuilder with all the CA page content
+ */
 const combatAchievementPageBuilder = (combatAchievement: CombatAchievement) => {
   const builder = new MediaWikiBuilder();
 

--- a/src/scripts/combatAchievements/combatAchievements.ts
+++ b/src/scripts/combatAchievements/combatAchievements.ts
@@ -4,7 +4,6 @@ import {
   TIER_ENUM_ID,
   TYPE_ENUM_ID,
   getCombatAchievement,
-  getEnumMap,
   writeCombatAchievement,
 } from "./utils";
 import {
@@ -12,10 +11,17 @@ import {
   CacheFileType,
   getCacheProviderGithub,
   getCacheProviderLocal,
+  getEnumMap,
 } from "../../utils/cache";
 import { Enum, Struct } from "../../utils/cache2";
 import { LazyPromise } from "../../utils/cache2/LazyPromise";
 
+/**
+ * Generate Combat Achievement pages from the cache.
+ * @param method The cache source: github vs local
+ * @param version The version of the cache to generate CA pages for
+ * @param type The cache type: disk vs flat
+ */
 const generateCombatAchievements = async (
   method: CacheSource,
   version: string,

--- a/src/scripts/combatAchievements/combatAchievements.ts
+++ b/src/scripts/combatAchievements/combatAchievements.ts
@@ -1,9 +1,19 @@
 import {
+  CA_TASKS,
+  MONSTER_MAP_ENUM_ID,
+  TIER_ENUM_ID,
+  TYPE_ENUM_ID,
+  getCombatAchievement,
+  getEnumMap,
+  writeCombatAchievement,
+} from "./utils";
+import {
   CacheSource,
   CacheFileType,
   getCacheProviderGithub,
   getCacheProviderLocal,
 } from "../../utils/cache";
+import { Enum, Struct } from "../../utils/cache2";
 import { LazyPromise } from "../../utils/cache2/LazyPromise";
 
 const generateCombatAchievements = async (
@@ -16,6 +26,27 @@ const generateCombatAchievements = async (
       ? getCacheProviderGithub(version)
       : getCacheProviderLocal(version, type)
   ).asPromise();
+
+  const tierMap = await getEnumMap(cache, TIER_ENUM_ID);
+  const typeMap = await getEnumMap(cache, TYPE_ENUM_ID);
+  const monsterMap = await getEnumMap(cache, MONSTER_MAP_ENUM_ID);
+
+  CA_TASKS.forEach(async (tierTasksEnum) => {
+    const tasksEnum = await Enum.load(cache, tierTasksEnum);
+    console.log(
+      `Loading CA ${tierTasksEnum} tier: ${tasksEnum.map.size} tasks.`
+    );
+    tasksEnum.map.forEach(async (taskStructId) => {
+      const taskStruct = await Struct.load(cache, parseInt(`${taskStructId}`));
+      const combatAchievement = getCombatAchievement(
+        taskStruct,
+        tierMap,
+        typeMap,
+        monsterMap
+      );
+      writeCombatAchievement(combatAchievement);
+    });
+  });
 };
 
 export default generateCombatAchievements;

--- a/src/scripts/combatAchievements/combatAchievements.ts
+++ b/src/scripts/combatAchievements/combatAchievements.ts
@@ -1,0 +1,21 @@
+import {
+  CacheSource,
+  CacheFileType,
+  getCacheProviderGithub,
+  getCacheProviderLocal,
+} from "../../utils/cache";
+import { LazyPromise } from "../../utils/cache2/LazyPromise";
+
+const generateCombatAchievements = async (
+  method: CacheSource,
+  version: string,
+  type: CacheFileType
+) => {
+  const cache = new LazyPromise(() =>
+    method === "github"
+      ? getCacheProviderGithub(version)
+      : getCacheProviderLocal(version, type)
+  ).asPromise();
+};
+
+export default generateCombatAchievements;

--- a/src/scripts/combatAchievements/index.ts
+++ b/src/scripts/combatAchievements/index.ts
@@ -1,0 +1,3 @@
+import generateCombatAchievements from "./combatAchievements";
+
+export default generateCombatAchievements;

--- a/src/scripts/combatAchievements/types.ts
+++ b/src/scripts/combatAchievements/types.ts
@@ -1,0 +1,24 @@
+export type CombatAchievementTier =
+  | "Easy"
+  | "Medium"
+  | "Hard"
+  | "Elite"
+  | "Master"
+  | "Grandmaster";
+
+export type CombatAchievementType =
+  | "Stamina"
+  | "Perfection"
+  | "Kill Count"
+  | "Mechanical"
+  | "Restriction"
+  | "Speed";
+
+export type CombatAchievement = {
+  description: string;
+  id: number;
+  monster: string;
+  tier: CombatAchievementTier;
+  type: CombatAchievementType;
+  title: string;
+};

--- a/src/scripts/combatAchievements/utils.ts
+++ b/src/scripts/combatAchievements/utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Enums
+ */
+export const TIER_ENUM_ID = 3967;
+export const TYPE_ENUM_ID = 3968;
+export const TIER_MAP_ENUM_ID = 3980;
+export const MONSTER_MAP_ENUM_ID = 3970;
+export const CA_TASK_MAP = {
+  0: 3981,
+  1: 3982,
+  2: 3983,
+  3: 3984,
+  4: 3985,
+  5: 3986,
+};
+
+/**
+ * Params
+ */
+export const CAID_PARAM_ID = 1306;
+export const TITLE_PARAM_ID = 1308;
+export const DESCRIPTION_PARAM_ID = 1309;
+export const TIER_PARAM_ID = 1310;
+export const TYPE_PARAM_ID = 1311;

--- a/src/scripts/combatAchievements/utils.ts
+++ b/src/scripts/combatAchievements/utils.ts
@@ -1,4 +1,3 @@
-import { MediaWikiBuilder } from "@osrs-wiki/mediawiki-builder";
 import { mkdir, writeFile } from "fs/promises";
 
 import combatAchievementPageBuilder from "./builder";
@@ -7,13 +6,7 @@ import {
   CombatAchievementTier,
   CombatAchievementType,
 } from "./types";
-import {
-  DiskCacheProvider,
-  Enum,
-  FlatCacheProvider,
-  ParamID,
-  Struct,
-} from "../../utils/cache2";
+import { ParamID, Struct } from "../../utils/cache2";
 
 /**
  * Enums
@@ -71,14 +64,11 @@ export const getCombatAchievement = (
   };
 };
 
-export const getEnumMap = async (
-  cache: Promise<FlatCacheProvider | DiskCacheProvider>,
-  id: number
-) => {
-  const tiers = await Enum.load(cache, id);
-  return tiers.map;
-};
-
+/**
+ * Write a CombatAchievement to a file.
+ *  The file name is the title of the achievement.
+ * @param combatAchievement The CombatAchievement object
+ */
 export const writeCombatAchievement = async (
   combatAchievement: CombatAchievement
 ) => {

--- a/src/scripts/combatAchievements/utils.ts
+++ b/src/scripts/combatAchievements/utils.ts
@@ -1,3 +1,20 @@
+import { MediaWikiBuilder } from "@osrs-wiki/mediawiki-builder";
+import { mkdir, writeFile } from "fs/promises";
+
+import combatAchievementPageBuilder from "./builder";
+import {
+  CombatAchievement,
+  CombatAchievementTier,
+  CombatAchievementType,
+} from "./types";
+import {
+  DiskCacheProvider,
+  Enum,
+  FlatCacheProvider,
+  ParamID,
+  Struct,
+} from "../../utils/cache2";
+
 /**
  * Enums
  */
@@ -5,14 +22,7 @@ export const TIER_ENUM_ID = 3967;
 export const TYPE_ENUM_ID = 3968;
 export const TIER_MAP_ENUM_ID = 3980;
 export const MONSTER_MAP_ENUM_ID = 3970;
-export const CA_TASK_MAP = {
-  0: 3981,
-  1: 3982,
-  2: 3983,
-  3: 3984,
-  4: 3985,
-  5: 3986,
-};
+export const CA_TASKS = [3981, 3982, 3983, 3984, 3985, 3986];
 
 /**
  * Params
@@ -22,3 +32,64 @@ export const TITLE_PARAM_ID = 1308;
 export const DESCRIPTION_PARAM_ID = 1309;
 export const TIER_PARAM_ID = 1310;
 export const TYPE_PARAM_ID = 1311;
+export const MONSTER_PARAM_ID = 1312;
+
+/**
+ * Generate a CombatAchievement type from the cache.
+ * @param struct The struct of the CA task
+ * @param tierMap A map of tier keys to tier strings
+ * @param typeMap A map of type keys to type strings
+ * @param monsterMap A map of monster keys to monster strings
+ * @returns A {CombatAchievement}
+ */
+export const getCombatAchievement = (
+  struct: Struct,
+  tierMap: Map<number, string | number>,
+  typeMap: Map<number, string | number>,
+  monsterMap: Map<number, string | number>
+): CombatAchievement => {
+  const id = struct.params.get(CAID_PARAM_ID as ParamID) as number;
+  const title = struct.params.get(TITLE_PARAM_ID as ParamID) as string;
+  const description = struct.params.get(
+    DESCRIPTION_PARAM_ID as ParamID
+  ) as string;
+  const monsterKey = struct.params.get(MONSTER_PARAM_ID as ParamID) as number;
+  const tierKey = struct.params.get(TIER_PARAM_ID as ParamID) as number;
+  const typeKey = struct.params.get(TYPE_PARAM_ID as ParamID) as number;
+
+  const monster = monsterMap.get(monsterKey) as string;
+  const tier = tierMap.get(tierKey) as CombatAchievementTier;
+  const type = typeMap.get(typeKey) as CombatAchievementType;
+
+  return {
+    id,
+    title,
+    description,
+    monster,
+    tier,
+    type,
+  };
+};
+
+export const getEnumMap = async (
+  cache: Promise<FlatCacheProvider | DiskCacheProvider>,
+  id: number
+) => {
+  const tiers = await Enum.load(cache, id);
+  return tiers.map;
+};
+
+export const writeCombatAchievement = async (
+  combatAchievement: CombatAchievement
+) => {
+  const builder = combatAchievementPageBuilder(combatAchievement);
+
+  const dir = `./out/combatAchievements/${combatAchievement.tier}`;
+  const fileName = `${dir}/${combatAchievement.title}.txt`;
+  try {
+    await mkdir(dir, { recursive: true });
+    writeFile(fileName, builder.build());
+  } catch (e) {
+    console.error(`Error creating CA file: ${fileName}`, e);
+  }
+};

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,6 +1,6 @@
 import { readFile } from "fs/promises";
 
-import { DiskCacheProvider, FlatCacheProvider } from "./cache2";
+import { DiskCacheProvider, Enum, FlatCacheProvider } from "./cache2";
 
 export type CacheSource = "github" | "local";
 export type CacheFileType = "flat" | "disk";
@@ -47,4 +47,12 @@ export const getCacheProviderGithub = async (version = "master") => {
       return new Uint8Array(ab);
     },
   });
+};
+
+export const getEnumMap = async (
+  cache: Promise<FlatCacheProvider | DiskCacheProvider>,
+  id: number
+) => {
+  const tiers = await Enum.load(cache, id);
+  return tiers.map;
 };

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,2 +1,16 @@
 export const capitalize = (word: string) =>
   word.charAt(0).toUpperCase() + word.slice(1);
+
+export const lowerCaseFirst = (value: string) =>
+  value.charAt(0).toLowerCase() + value.slice(1);
+
+export const vowel = (noun: string) => {
+  const vowels = ["a", "e", "i", "o", "u"];
+  const startsWith = vowels.filter((vowel) =>
+    noun
+      .toLocaleLowerCase()
+      .replaceAll(/[^a-z]/g, "")
+      .startsWith(vowel)
+  );
+  return startsWith.length > 0 ? "an" : "a";
+};


### PR DESCRIPTION
**Description**
This PR adds support for generating Combat Achievement pages.

Example:
```
{{Infobox Combat Achievement
|name = Akkhan't Do it
|image = [[File:XM: Tombs of Amascut.png|150px]]
|release = 
|update = 
|members = Yes
|description = Defeat Akkha with all Akkha invocations activated and the path levelled up to at least four, without dying yourself.
|tier = Grandmaster
|monster = XM: Tombs of Amascut
|type = Mechanical
|id = 450
}}
'''Akkhan't Do it''' is a [[Combat Achievements/Grandmaster|grandmaster combat achievement]] which requires the player to defeat Akkha with all Akkha invocations activated and the path levelled up to at least four, without dying yourself.

{{Combat Achievements}}

```