### PR TITLE
[#29] Add support for sprite diffs

### DIFF
--- a/.changeset/heavy-rings-lie.md
+++ b/.changeset/heavy-rings-lie.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": minor
+---
+
+Add support for Sprite diffs

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ node_modules
 .vscode/
 
 ./**/.DS_Store
+.DS_Store

--- a/src/scripts/differences/builder/builder.types.ts
+++ b/src/scripts/differences/builder/builder.types.ts
@@ -7,6 +7,7 @@ import {
   NPC,
   Obj,
   Param,
+  Sprites,
   Struct,
 } from "../../../utils/cache2";
 import { PerFileLoadable } from "../../../utils/cache2/Loadable";
@@ -30,6 +31,7 @@ export type IndexFeatures =
   | IndexFeature<NPC, "Npcs">
   | IndexFeature<Obj, "Objects">
   | IndexFeature<Param, "Params">
+  | IndexFeature<Sprites, "Sprites">
   | IndexFeature<Struct, "Structs">;
 
 export const resultNameMap: { [key in Difference]: string } = {
@@ -116,6 +118,15 @@ export const indexNameMap: {
       urls: {
         abex: "https://abextm.github.io/cache2/#/viewer/dbrow/",
       },
+    },
+  },
+  [IndexType.Sprites]: {
+    name: "Sprites",
+    identifiers: ["id"],
+    fields: ["width", "height"],
+    urls: {
+      chisel: "",
+      abex: "https://abextm.github.io/cache2/#/viewer/sprite/",
     },
   },
 };

--- a/src/scripts/differences/file/content/sprites.ts
+++ b/src/scripts/differences/file/content/sprites.ts
@@ -1,0 +1,31 @@
+import _ from "underscore";
+
+import { Reader, SpriteID, Sprites } from "../../../../utils/cache2";
+import { CompareFn } from "../../differences.types";
+import { getFileDifferences } from "../file.utils";
+
+const compareSprites: CompareFn = ({ oldFile, newFile }) => {
+  const oldEntry = oldFile
+    ? Sprites.decode(
+        new Reader(oldFile.file.data, {
+          era: "osrs",
+          indexRevision: oldFile.index.revision,
+        }),
+        <SpriteID>oldFile.archive.archive
+      )
+    : undefined;
+
+  const newEntry = newFile
+    ? Sprites.decode(
+        new Reader(newFile.file.data, {
+          era: "osrs",
+          indexRevision: newFile.index.revision,
+        }),
+        <SpriteID>newFile.archive.archive
+      )
+    : undefined;
+
+  return getFileDifferences(oldEntry, newEntry);
+};
+
+export default compareSprites;

--- a/src/scripts/differences/file/file.ts
+++ b/src/scripts/differences/file/file.ts
@@ -4,6 +4,7 @@ import compareItems from "./content/items";
 import compareNpcs from "./content/npcs";
 import compareObjects from "./content/objects";
 import compareParams from "./content/params";
+import compareSprites from "./content/sprites";
 import compareStructs from "./content/struct";
 import { ConfigType, IndexType } from "../../../utils/cache2";
 import { CompareFn, FileDifferences } from "../differences.types";
@@ -23,6 +24,7 @@ const indexMap: {
     [ConfigType.Params]: compareParams,
     [ConfigType.Struct]: compareStructs,
   },
+  [IndexType.Sprites]: compareSprites,
 };
 
 /**


### PR DESCRIPTION
**Description**
Resolves #29 

This PR also makes the difference checking only apply to items supported in the `indexNameMap`. This means that all indices will not have differences checked unless they have a supported output. Additionally, the JSON difference output is no longer written to a file.