### PR TITLE
Temporarily disable sprite diffs

### DIFF
--- a/.changeset/old-jeans-chew.md
+++ b/.changeset/old-jeans-chew.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+Temporarily disable sprite diffs

--- a/src/scripts/differences/builder/builder.types.ts
+++ b/src/scripts/differences/builder/builder.types.ts
@@ -120,7 +120,7 @@ export const indexNameMap: {
       },
     },
   },
-  [IndexType.Sprites]: {
+  /*[IndexType.Sprites]: {
     name: "Sprites",
     identifiers: ["id"],
     fields: ["width", "height"],
@@ -128,5 +128,5 @@ export const indexNameMap: {
       chisel: "",
       abex: "https://abextm.github.io/cache2/#/viewer/sprite/",
     },
-  },
+  },*/
 };


### PR DESCRIPTION
**Description**
Temporarily disable sprite diffs until the diff checking for them is fixed and also until index-level content building is supported.