### PR TITLE
Combat Achievement improvements

### DIFF
--- a/.changeset/wild-drinks-move.md
+++ b/.changeset/wild-drinks-move.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+Combat achievement improvements

--- a/src/scripts/combatAchievements/__tests__/__snapshots__/builder.test.ts.snap
+++ b/src/scripts/combatAchievements/__tests__/__snapshots__/builder.test.ts.snap
@@ -13,6 +13,9 @@ exports[`combatAchievementPageBuilder it should build with all fields 1`] = `
 }}
 '''Testing''' is an [[Combat Achievements/Elite|elite combat achievement]] which requires the player to testing a Description
 
+==Other tasks==
+{{Combat Achievements list|Big Monster}}
+
 {{Combat Achievements}}
 "
 `;

--- a/src/scripts/combatAchievements/builder.ts
+++ b/src/scripts/combatAchievements/builder.ts
@@ -3,6 +3,7 @@ import {
   MediaWikiBuilder,
   MediaWikiDate,
   MediaWikiFile,
+  MediaWikiHeader,
   MediaWikiLink,
   MediaWikiTemplate,
   MediaWikiText,
@@ -44,6 +45,11 @@ const combatAchievementPageBuilder = (combatAchievement: CombatAchievement) => {
   infobox.add("type", combatAchievement.type);
   infobox.add("id", `${combatAchievement.id}`);
 
+  const combatAchievementsList = new MediaWikiTemplate(
+    "Combat Achievements list"
+  );
+  combatAchievementsList.add("", combatAchievement.monster);
+
   builder.addContents([
     infobox,
     new MediaWikiText(combatAchievement.title, { bold: true }),
@@ -58,6 +64,10 @@ const combatAchievementPageBuilder = (combatAchievement: CombatAchievement) => {
       )}`
     ),
     new MediaWikiBreak(),
+    new MediaWikiBreak(),
+    new MediaWikiHeader("Other tasks", 2),
+    new MediaWikiBreak(),
+    combatAchievementsList,
     new MediaWikiBreak(),
     new MediaWikiTemplate("Combat Achievements"),
   ]);

--- a/src/scripts/combatAchievements/utils.ts
+++ b/src/scripts/combatAchievements/utils.ts
@@ -7,6 +7,7 @@ import {
   CombatAchievementType,
 } from "./types";
 import { ParamID, Struct } from "../../utils/cache2";
+import { formatFileName } from "../../utils/files";
 
 /**
  * Enums
@@ -74,8 +75,10 @@ export const writeCombatAchievement = async (
 ) => {
   const builder = combatAchievementPageBuilder(combatAchievement);
 
-  const dir = `./out/combatAchievements/${combatAchievement.tier}`;
-  const fileName = `${dir}/${combatAchievement.title}.txt`;
+  const dir = formatFileName(
+    `./out/combatAchievements/${combatAchievement.monster}`
+  );
+  const fileName = formatFileName(`${dir}/${combatAchievement.title}.txt`);
   try {
     await mkdir(dir, { recursive: true });
     writeFile(fileName, builder.build());

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,0 +1,3 @@
+export const formatFileName = (name: string) => {
+  return name.replaceAll(":", "-").replaceAll("?", "");
+};


### PR DESCRIPTION
**Description**
- Add "other tasks" section to CA pages
- Group CA page files by monster, rather than by tier