### PR TITLE
Fix render file name formatting

### DIFF
--- a/.changeset/hot-lobsters-change.md
+++ b/.changeset/hot-lobsters-change.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+Format render file names

--- a/.changeset/plenty-bobcats-wonder.md
+++ b/.changeset/plenty-bobcats-wonder.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+Add varp ScriptVarType

--- a/src/scripts/differences/file/content/items.ts
+++ b/src/scripts/differences/file/content/items.ts
@@ -34,7 +34,7 @@ const compareItems: CompareFn = ({ oldFile, newFile }) => {
     buildItemInfobox(newEntry);
   }
 
-  if (Context.renders) {
+  if (Context.renders && newEntry) {
     renderItems(newEntry);
   }
 

--- a/src/scripts/differences/file/content/npcs.ts
+++ b/src/scripts/differences/file/content/npcs.ts
@@ -41,7 +41,7 @@ const compareNpcs: CompareFn = ({ oldFile, newFile }) => {
     }
   }
 
-  if (Context.renders) {
+  if (Context.renders && newEntry) {
     renderNpcs(newEntry);
   }
 

--- a/src/scripts/renders/items.ts
+++ b/src/scripts/renders/items.ts
@@ -3,6 +3,7 @@ import { copyFile, mkdir } from "fs/promises";
 
 import Context from "../../context";
 import { Item } from "../../utils/cache2";
+import { formatFileName } from "../../utils/files";
 
 export const renderItems = async (item: Item) => {
   if (item.name.toLocaleLowerCase() === "null") {
@@ -16,11 +17,11 @@ export const renderItems = async (item: Item) => {
     await mkdir("./out/renders/miniitems", { recursive: true });
     copyFile(
       "./data/renders/item/" + item.id + ".png",
-      "./out/renders/item/" + item.name + " detail.png"
+      formatFileName("./out/renders/item/" + item.name + " detail.png")
     );
     copyFile(
       "./data/renders/miniitems/" + item.id + ".png",
-      "./out/renders/miniitems/" + item.name + ".png"
+      formatFileName("./out/renders/miniitems/" + item.name + ".png")
     );
   }
 };

--- a/src/scripts/renders/npcs.ts
+++ b/src/scripts/renders/npcs.ts
@@ -3,6 +3,7 @@ import { copyFile, mkdir } from "fs/promises";
 
 import Context from "../../context";
 import { NPC } from "../../utils/cache2";
+import { formatFileName } from "../../utils/files";
 
 export const renderNpcs = async (npc: NPC) => {
   if (npc.name.toLocaleLowerCase() === "null") {
@@ -12,13 +13,13 @@ export const renderNpcs = async (npc: NPC) => {
     await mkdir("./out/renders/npc", { recursive: true });
     copyFile(
       "./data/renders/npc/" + npc.id + ".png",
-      "./out/renders/npc/" + npc.name + ".png"
+      formatFileName("./out/renders/npc/" + npc.name + ".png")
     );
     if (existsSync("./data/renders/chathead/" + npc.id + ".png")) {
       await mkdir("./out/renders/chathead", { recursive: true });
       copyFile(
         "./data/renders/chathead/" + npc.id + ".png",
-        "./out/renders/chathead/" + npc.name + ".png"
+        formatFileName("./out/renders/chathead/" + npc.name + ".png")
       );
     }
   }

--- a/src/utils/cache2/ScriptVarType.ts
+++ b/src/utils/cache2/ScriptVarType.ts
@@ -227,6 +227,12 @@ export class ScriptVarType {
     jag: "dbrow",
     type: "DBRowID",
   });
+  static readonly varp = this.t({
+    id: 209,
+    char: "7",
+    jag: "varp",
+    type: "VarPID",
+  });
 
   // 49, 56, 71, 110, 115, 116 are base long
 }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,3 +1,6 @@
 export const formatFileName = (name: string) => {
-  return name.replaceAll(":", "-").replaceAll("?", "");
+  return name
+    .replaceAll(":", "-")
+    .replaceAll("?", "")
+    .replaceAll(/<[^>]*>/g, "");
 };


### PR DESCRIPTION
**Description**
Fix formatting render renamed files. This is to handle cases like `<col=blah>Pet Rock</col>`.