### PR TITLE
Fix duplicate rendering & add npc dialogue

### DIFF
--- a/.changeset/dirty-friends-laugh.md
+++ b/.changeset/dirty-friends-laugh.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": minor
+---
+
+Add Dialogue section to npc's with Talk-to action

--- a/.changeset/public-pugs-prove.md
+++ b/.changeset/public-pugs-prove.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+Remove duplicate rendering when Context.renders and Context.pages are both set

--- a/src/mediawiki/pages/npc/__snapshots__/npc.test.ts.snap
+++ b/src/mediawiki/pages/npc/__snapshots__/npc.test.ts.snap
@@ -34,6 +34,24 @@ exports[`npcPageBuilder should build npc infobox without combat level 1`] = `
 '''name'''"
 `;
 
+exports[`npcPageBuilder should build npc page with transcript 1`] = `
+"{{New Content}}
+{{Infobox Monster
+|name = name
+|image = [[File:name.png|120px]]
+|members = Yes
+|combat = 1
+|examine = 
+|id = 1
+}}
+[[File:name chathead.png|left]]
+'''name'''
+
+==Dialogue==
+{{Hastranscript|npc}}
+"
+`;
+
 exports[`npcPageBuilder should use beta id when Context.beta is true 1`] = `
 "{{New Content}}
 {{Infobox Monster

--- a/src/mediawiki/pages/npc/npc.test.ts
+++ b/src/mediawiki/pages/npc/npc.test.ts
@@ -54,4 +54,16 @@ describe("npcPageBuilder", () => {
 
     Context.beta = originalBeta;
   });
+
+  it("should build npc page with transcript", async () => {
+    const builder = await npcPageBuilder({
+      name: "name",
+      combatLevel: 1,
+      actions: ["Talk-to"],
+      id: 1 as NPCID,
+      params: new Params(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    expect(builder?.build()).toMatchSnapshot();
+  });
 });

--- a/src/mediawiki/pages/npc/npc.ts
+++ b/src/mediawiki/pages/npc/npc.ts
@@ -2,6 +2,7 @@ import {
   MediaWikiBreak,
   MediaWikiBuilder,
   MediaWikiFile,
+  MediaWikiHeader,
   MediaWikiTemplate,
   MediaWikiText,
 } from "@osrs-wiki/mediawiki-builder";
@@ -24,6 +25,18 @@ export const npcPageBuilder = (npc: NPC) => {
     new MediaWikiBreak(),
     new MediaWikiText(npc.name, { bold: true }),
   ]);
+
+  if (npc.actions.includes("Talk-to")) {
+    const transcriptTemplate = new MediaWikiTemplate("Hastranscript");
+    transcriptTemplate.add("", "npc");
+    builder.addContents([
+      new MediaWikiBreak(),
+      new MediaWikiBreak(),
+      new MediaWikiHeader("Dialogue", 2),
+      new MediaWikiBreak(),
+      transcriptTemplate,
+    ]);
+  }
 
   return builder;
 };

--- a/src/tasks/differences/listeners/types/items.ts
+++ b/src/tasks/differences/listeners/types/items.ts
@@ -55,9 +55,7 @@ export const itemListener: CacheChangeListener = {
       newEntry.name.toLowerCase() !== "null"
     ) {
       writeItemPage(newEntry);
-    }
-
-    if (Context.renders && newEntry) {
+    } else if (Context.renders && newEntry) {
       renderItems(newEntry);
     }
   },

--- a/src/tasks/differences/listeners/types/npcs.ts
+++ b/src/tasks/differences/listeners/types/npcs.ts
@@ -55,9 +55,7 @@ export const npcListener: CacheChangeListener = {
       newEntry.name.toLowerCase() !== "null"
     ) {
       writeNpcPage(newEntry);
-    }
-
-    if (Context.renders && newEntry) {
+    } else if (Context.renders && newEntry) {
       renderNpcs(newEntry);
     }
   },

--- a/src/tasks/differences/listeners/types/objects.ts
+++ b/src/tasks/differences/listeners/types/objects.ts
@@ -55,9 +55,7 @@ export const objectListener: CacheChangeListener = {
       newEntry.name.toLowerCase() !== "null"
     ) {
       writeSceneryPage(newEntry);
-    }
-
-    if (Context.renders && newEntry) {
+    } else if (Context.renders && newEntry) {
       renderScenery(newEntry);
     }
   },


### PR DESCRIPTION
**Description**
This pull request introduces a new feature to add dialogue sections for NPCs with "Talk-to" actions, resolves a rendering issue when both `Context.renders` and `Context.pages` are set, and includes minor code improvements. Below is a breakdown of the most important changes:

### New Feature: Dialogue Section for NPCs
* Added logic in `npcPageBuilder` to include a "Dialogue" section with a transcript template for NPCs that have the "Talk-to" action (`src/mediawiki/pages/npc/npc.ts`).
* Updated tests to verify the new dialogue section functionality, including adding a new snapshot and a corresponding test case (`src/mediawiki/pages/npc/__snapshots__/npc.test.ts.snap`, `src/mediawiki/pages/npc/npc.test.ts`). [[1]](diffhunk://#diff-9c1ca6b7ede656d94e5276ed04884c0c2f4e066a2ce9990feec8d0ac4a80f11fR37-R54) [[2]](diffhunk://#diff-519dc6b738cc74ae7dfc18798d18171611c8e6d0eaf2100eeb7f352cc882323cR57-R68)

### Bug Fix: Duplicate Rendering
* Fixed an issue where duplicate rendering occurred when both `Context.renders` and `Context.pages` were set, by consolidating the conditional logic in multiple listeners (`src/tasks/differences/listeners/types/items.ts`, `src/tasks/differences/listeners/types/npcs.ts`, `src/tasks/differences/listeners/types/objects.ts`). [[1]](diffhunk://#diff-37be6aa3047e22e719ad3459cd57728c815867a7346dfa4361e6df4a7a36cc65L58-R58) [[2]](diffhunk://#diff-ca7644248acc673c04f64934489a6835ba8d9c032ee17131398361421cf4d625L58-R58) [[3]](diffhunk://#diff-56ba37d243c6d925ab3c4a26450364aae9922868a29c6a7d16ec24acb01d95d3L58-R58)

### Miscellaneous Improvements
* Added `MediaWikiHeader` import to support the new dialogue section header (`src/mediawiki/pages/npc/npc.ts`).

### Changeset Updates
* Documented the addition of the dialogue section as a minor change and the rendering fix as a patch in the changeset files (`.changeset/dirty-friends-laugh.md`, `.changeset/public-pugs-prove.md`). [[1]](diffhunk://#diff-ee3f63a9397d6d1bc13d50066bd5206222cb9be159c091bf39c6a18c6f634941R1-R5) [[2]](diffhunk://#diff-76be8719289edcdb0c4df12329a9cff6940dd29296e2b9b32ef0cd0e781f6295R1-R5)