### PR TITLE
feat: Add support for cache revision 237

### DIFF
--- a/.changeset/blue-lions-love.md
+++ b/.changeset/blue-lions-love.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": minor
+---
+
+Support for revision 237

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osrs-wiki/cache-mediawiki",
-  "version": "1.11.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osrs-wiki/cache-mediawiki",
-      "version": "1.11.0",
+      "version": "1.12.1",
       "license": "ISC",
       "dependencies": {
         "@osrs-wiki/mediawiki-builder": "^1.9.2",
@@ -90,6 +90,7 @@
       "integrity": "sha512-cQbWBpxcbbs/IUredIPkHiAGULLV8iwgNRMFzvbhEXISp4f3rUUXE5+TIw6KwUWUR3DwyI6gmBRnmAtYaWehwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -185,7 +186,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
       "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -444,7 +444,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
       "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -2227,6 +2226,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
       "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2325,6 +2325,7 @@
       "integrity": "sha512-nzjFAN8WEu6yPRDizIFyzAfgK7nybPodMNFGNH0M9tei2gYnYszRDqVA0xlnRjkl7Hkx2vYrEdb6fP2a21cG1g==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.59.1",
         "@typescript-eslint/types": "5.59.1",
@@ -2493,6 +2494,7 @@
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3776,6 +3778,7 @@
       "integrity": "sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -5621,6 +5624,7 @@
       "integrity": "sha512-Tuf05DwLeCh2cfWCQbcz9UxldoDyiR1E9Igaei5khjonKncYdc6LDfynKCEWozK0oLE3GD+xKAo2u8x/0s6GOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^28.1.2",
         "@jest/types": "^28.1.1",
@@ -8384,6 +8388,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/mediawiki/pages/differences/differences.types.ts
+++ b/src/mediawiki/pages/differences/differences.types.ts
@@ -95,7 +95,7 @@ export const indexNameMap: {
     [ConfigType.Object]: {
       name: "Objects",
       identifiers: ["name", "id", "gameVal"],
-      fields: ["actions"],
+      fields: ["ops"],
       urls: {
         id: [
           "https://chisel.weirdgloop.org/moid/object_id.html#{id}",
@@ -117,7 +117,7 @@ export const indexNameMap: {
     [ConfigType.Npc]: {
       name: "Npcs",
       identifiers: ["name", "id", "gameVal"],
-      fields: ["combatLevel", "actions"],
+      fields: ["combatLevel", "ops"],
       urls: {
         id: [
           "https://chisel.weirdgloop.org/moid/npc_id.html#{id}",
@@ -134,7 +134,7 @@ export const indexNameMap: {
         "isGrandExchangable",
         "isStackable",
         "noteLinkedItem",
-        "inventoryActions",
+        "inventoryOps",
         "placeholderLinkedItem",
         "price",
         "weight",
@@ -149,7 +149,7 @@ export const indexNameMap: {
     [ConfigType.Params]: {
       name: "Params",
       identifiers: ["id"],
-      fields: ["type", "defaultInt", "defaultString", "isMembers"],
+      fields: ["typeChar", "defaultInt", "defaultString", "isMembers"],
       urls: {
         id: [
           "https://chisel.weirdgloop.org/structs/index.html?type=enums&id={id}",

--- a/src/mediawiki/pages/item/item.test.ts
+++ b/src/mediawiki/pages/item/item.test.ts
@@ -17,7 +17,14 @@ import {
   RANGED_AMMO_STRENGTH_PARAM,
   RANGED_EQUIPMENT_STRENGTH_PARAM,
 } from "@/types/params";
-import { CategoryID, Item, ItemID, Params, WearPos } from "@/utils/cache2";
+import {
+  CategoryID,
+  EntityOps,
+  Item,
+  ItemID,
+  Params,
+  WearPos,
+} from "@/utils/cache2";
 
 const BASE_ITEM: Item = {
   name: "Test Item",
@@ -43,8 +50,8 @@ const BASE_ITEM: Item = {
   femaleModel: undefined,
   femaleOffset: 0,
   femaleModel1: undefined,
-  groundActions: [],
-  inventoryActions: ["Test Action"],
+  groundOps: new EntityOps(),
+  inventoryOps: ["Test Action"],
   subops: [],
   recolorFrom: [],
   recolorTo: [],
@@ -55,8 +62,8 @@ const BASE_ITEM: Item = {
   femaleModel2: undefined,
   maleChatheadModel: undefined,
   femaleChatheadModel: undefined,
-  maleChatheadModel2: undefined,
-  femaleChatheadModel2: undefined,
+  maleChatheadModel1: undefined,
+  femaleChatheadModel1: undefined,
   category: undefined,
   zan2d: 0,
   noteLinkedItem: undefined,
@@ -116,7 +123,7 @@ describe("Item Infobox", () => {
   test("Item infobox with sub ops", async () => {
     const itemInfobox = await itemPageBuilder({
       ...BASE_ITEM,
-      inventoryActions: ["Test Action 1", "Test Action 2", "Test Action 3"],
+      inventoryOps: ["Test Action 1", "Test Action 2", "Test Action 3"],
       subops: [["Sub Action 1"], ["Sub Action 2.1", "Sub Action 2.2"], []],
     });
     expect(itemInfobox.build()).toMatchSnapshot();

--- a/src/mediawiki/pages/npc/npc.test.ts
+++ b/src/mediawiki/pages/npc/npc.test.ts
@@ -1,7 +1,7 @@
 import npcPageBuilder from "./npc";
 import Context from "../../../context";
 
-import { NPC, NPCID, Params, CacheProvider } from "@/utils/cache2";
+import { EntityOps, NPC, NPCID, Params, CacheProvider } from "@/utils/cache2";
 
 // Mock NPC.load for multiChildren tests
 jest.mock("@/utils/cache2", () => ({
@@ -37,6 +37,10 @@ describe("npcPageBuilder", () => {
       id: id as NPCID,
       combatLevel,
       actions: ["Talk-to", "Trade"],
+      ops: new EntityOps([
+        [0, { text: "Talk-to" }],
+        [1, { text: "Trade" }],
+      ]),
       params: new Params(),
       size: 1,
       hitpoints: 1,
@@ -53,7 +57,10 @@ describe("npcPageBuilder", () => {
     const builder = await npcPageBuilder({
       name: "name",
       combatLevel: 1,
-      actions: ["action1", "action2"],
+      ops: new EntityOps([
+        [0, { text: "action1" }],
+        [1, { text: "action2" }],
+      ]),
       id: 1 as NPCID,
       params: new Params(),
       chatheadModels: [1, 2], // NPC with chathead models
@@ -66,7 +73,10 @@ describe("npcPageBuilder", () => {
     const builder = await npcPageBuilder({
       name: "name",
       combatLevel: 100,
-      actions: ["action1", "action2"],
+      ops: new EntityOps([
+        [0, { text: "action1" }],
+        [1, { text: "action2" }],
+      ]),
       id: 1 as NPCID,
       size: 2,
       hitpoints: 100,
@@ -88,7 +98,10 @@ describe("npcPageBuilder", () => {
     const builder = await npcPageBuilder({
       name: "name",
       combatLevel: 1,
-      actions: ["action1", "action2"],
+      ops: new EntityOps([
+        [0, { text: "action1" }],
+        [1, { text: "action2" }],
+      ]),
       id: 1 as NPCID,
       params: new Params(),
       chatheadModels: [1, 2], // NPC with chathead models
@@ -103,7 +116,7 @@ describe("npcPageBuilder", () => {
     const builder = await npcPageBuilder({
       name: "name",
       combatLevel: 1,
-      actions: ["Talk-to"],
+      ops: new EntityOps([[0, { text: "Talk-to" }]]),
       id: 1 as NPCID,
       params: new Params(),
       chatheadModels: [1, 2], // NPC with chathead models
@@ -116,7 +129,10 @@ describe("npcPageBuilder", () => {
     const builder = await npcPageBuilder({
       name: "name",
       combatLevel: 1,
-      actions: ["action1", "action2"],
+      ops: new EntityOps([
+        [0, { text: "action1" }],
+        [1, { text: "action2" }],
+      ]),
       id: 1 as NPCID,
       params: new Params(),
       chatheadModels: [], // NPC without chathead models
@@ -129,7 +145,10 @@ describe("npcPageBuilder", () => {
     const builder = await npcPageBuilder({
       name: "name",
       combatLevel: 1,
-      actions: ["action1", "action2"],
+      ops: new EntityOps([
+        [0, { text: "action1" }],
+        [1, { text: "action2" }],
+      ]),
       id: 1 as NPCID,
       params: new Params(),
       chatheadModels: [1, 2], // NPC with chathead models
@@ -142,7 +161,10 @@ describe("npcPageBuilder", () => {
     const builder = await npcPageBuilder({
       name: "<col=00ffff>Tornado</col>",
       combatLevel: 1,
-      actions: ["action1", "action2"],
+      ops: new EntityOps([
+        [0, { text: "action1" }],
+        [1, { text: "action2" }],
+      ]),
       id: 1 as NPCID,
       params: new Params(),
       chatheadModels: [1, 2], // NPC with chathead models

--- a/src/mediawiki/pages/npc/npc.ts
+++ b/src/mediawiki/pages/npc/npc.ts
@@ -120,7 +120,9 @@ export const npcPageBuilder = async (
     infoboxContent = new SwitchInfobox(switchItems);
   }
 
-  const hasDialogue = npcArray.some((npc) => npc.actions.includes("Talk-to"));
+  const hasDialogue = npcArray.some((npc) =>
+    [...npc.ops.values()].some((op) => op.text === "Talk-to")
+  );
 
   const builder = new MediaWikiBuilder();
 

--- a/src/mediawiki/pages/npc/npc.utils.test.ts
+++ b/src/mediawiki/pages/npc/npc.utils.test.ts
@@ -1,6 +1,6 @@
 import { groupNpcsByType } from "./npc.utils";
 
-import { NPC, NPCID, Params } from "@/utils/cache2";
+import { EntityOps, NPC, NPCID, Params } from "@/utils/cache2";
 
 const createMockNpc = (
   name: string,
@@ -13,6 +13,10 @@ const createMockNpc = (
     id: id as NPCID,
     combatLevel,
     actions: ["Talk-to", "Trade"],
+    ops: new EntityOps([
+      [0, { text: "Talk-to" }],
+      [1, { text: "Trade" }],
+    ]),
     params: new Params(),
     size: 1,
     hitpoints: 1,

--- a/src/mediawiki/pages/scenery/scenery.test.ts
+++ b/src/mediawiki/pages/scenery/scenery.test.ts
@@ -2,7 +2,7 @@
 import sceneryPageBuilder from "./scenery";
 
 import Context from "@/context";
-import { CacheProvider, Location, ObjID } from "@/utils/cache2";
+import { CacheProvider, EntityOps, Location, ObjID } from "@/utils/cache2";
 import * as locationsModule from "@/utils/locations";
 
 // Mock the locations module
@@ -34,7 +34,10 @@ describe("sceneryPageBuilder", () => {
     // @ts-ignore Do not require all fields
     const builder = await sceneryPageBuilder({
       name: "name",
-      actions: ["action1", "action2"],
+      ops: new EntityOps([
+        [0, { text: "action1" }],
+        [1, { text: "action2" }],
+      ]),
       id: 1 as ObjID,
     });
     expect(builder?.build()).toMatchSnapshot();
@@ -48,7 +51,10 @@ describe("sceneryPageBuilder", () => {
     // @ts-ignore Do not require all fields
     const builder = await sceneryPageBuilder({
       name: "name",
-      actions: ["action1", "action2"],
+      ops: new EntityOps([
+        [0, { text: "action1" }],
+        [1, { text: "action2" }],
+      ]),
       id: 1 as ObjID,
     });
     expect(builder?.build()).toMatchSnapshot();
@@ -61,7 +67,10 @@ describe("sceneryPageBuilder", () => {
     // @ts-ignore Do not require all fields
     const builder = await sceneryPageBuilder({
       name: "<col=ff0000>Red Chest</col>",
-      actions: ["Open", "Search"],
+      ops: new EntityOps([
+        [0, { text: "Open" }],
+        [1, { text: "Search" }],
+      ]),
       id: 123 as ObjID,
     });
     expect(builder?.build()).toMatchSnapshot();
@@ -85,7 +94,7 @@ describe("sceneryPageBuilder", () => {
         // @ts-ignore Do not require all fields
         {
           name: "Altar",
-          actions: ["Pray"],
+          ops: new EntityOps([[0, { text: "Pray" }]]),
           id: 100 as ObjID,
         },
         mockCache
@@ -152,7 +161,7 @@ describe("sceneryPageBuilder", () => {
         // @ts-ignore Do not require all fields
         {
           name: "Tree",
-          actions: ["Chop down"],
+          ops: new EntityOps([[0, { text: "Chop down" }]]),
           id: 100 as ObjID,
         },
         mockCache
@@ -173,7 +182,7 @@ describe("sceneryPageBuilder", () => {
         // @ts-ignore Do not require all fields
         {
           name: "Mysterious Object",
-          actions: ["Examine"],
+          ops: new EntityOps([[0, { text: "Examine" }]]),
           id: 100 as ObjID,
         },
         mockCache
@@ -196,7 +205,7 @@ describe("sceneryPageBuilder", () => {
         // @ts-ignore Do not require all fields
         {
           name: "Broken Cache Object",
-          actions: ["Test"],
+          ops: new EntityOps([[0, { text: "Test" }]]),
           id: 100 as ObjID,
         },
         mockCache
@@ -221,7 +230,7 @@ describe("sceneryPageBuilder", () => {
       // @ts-ignore Do not require all fields
       const builder = await sceneryPageBuilder({
         name: "No Cache Object",
-        actions: ["Test"],
+        ops: new EntityOps([[0, { text: "Test" }]]),
         id: 100 as ObjID,
       });
 
@@ -286,7 +295,7 @@ describe("sceneryPageBuilder", () => {
         // @ts-ignore Do not require all fields
         {
           name: "Grouped Scenery",
-          actions: ["Use"],
+          ops: new EntityOps([[0, { text: "Use" }]]),
           id: 100 as ObjID,
         },
         mockCache

--- a/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.test.ts
+++ b/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.test.ts
@@ -19,7 +19,7 @@ import {
   STAB_ATTACK_PARAM,
   STAB_DEFENCE_PARAM,
 } from "@/types/params";
-import { Item, ItemID, Params, WearPos } from "@/utils/cache2";
+import { EntityOps, Item, ItemID, Params, WearPos } from "@/utils/cache2";
 
 const BASE_EQUIPABLE_ITEM: Item = {
   name: "Test Equipment",
@@ -45,8 +45,8 @@ const BASE_EQUIPABLE_ITEM: Item = {
   femaleModel: undefined,
   femaleOffset: 0,
   femaleModel1: undefined,
-  groundActions: [],
-  inventoryActions: ["Wield"],
+  groundOps: new EntityOps(),
+  inventoryOps: ["Wield"],
   subops: [],
   recolorFrom: [],
   recolorTo: [],
@@ -57,8 +57,8 @@ const BASE_EQUIPABLE_ITEM: Item = {
   femaleModel2: undefined,
   maleChatheadModel: undefined,
   femaleChatheadModel: undefined,
-  maleChatheadModel2: undefined,
-  femaleChatheadModel2: undefined,
+  maleChatheadModel1: undefined,
+  femaleChatheadModel1: undefined,
   category: undefined,
   zan2d: 0,
   noteLinkedItem: undefined,

--- a/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.utils.test.ts
+++ b/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.utils.test.ts
@@ -3,7 +3,7 @@ import {
   generateEquippedImageParams,
 } from "./InfoboxBonuses.utils";
 
-import { Item, ItemID, Params, WearPos } from "@/utils/cache2";
+import { EntityOps, Item, ItemID, Params, WearPos } from "@/utils/cache2";
 
 const BASE_ITEM: Item = {
   name: "Test Item",
@@ -29,8 +29,8 @@ const BASE_ITEM: Item = {
   femaleModel: undefined,
   femaleOffset: 0,
   femaleModel1: undefined,
-  groundActions: [],
-  inventoryActions: [],
+  groundOps: new EntityOps(),
+  inventoryOps: [],
   subops: [],
   recolorFrom: [],
   recolorTo: [],
@@ -41,8 +41,8 @@ const BASE_ITEM: Item = {
   femaleModel2: undefined,
   maleChatheadModel: undefined,
   femaleChatheadModel: undefined,
-  maleChatheadModel2: undefined,
-  femaleChatheadModel2: undefined,
+  maleChatheadModel1: undefined,
+  femaleChatheadModel1: undefined,
   category: undefined,
   zan2d: 0,
   noteLinkedItem: undefined,

--- a/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.utils.ts
+++ b/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.utils.ts
@@ -62,9 +62,19 @@ export type InfoboxBonusesData = {
  * @param bonus The bonus to format. Can be a string or a number.
  * @returns A formatted string representing the bonus.
  */
-export const formatBonus = (bonus: string | number) => {
-  const numberBonus = typeof bonus === "string" ? parseInt(bonus) : bonus;
-  return numberBonus > 0 ? `+${bonus}` : numberBonus < 0 ? `${bonus}` : "0";
+export const formatBonus = (bonus: string | number | bigint | undefined) => {
+  if (bonus === undefined) return "0";
+  const numberBonus =
+    typeof bonus === "string"
+      ? parseInt(bonus)
+      : typeof bonus === "bigint"
+      ? Number(bonus)
+      : bonus;
+  return numberBonus > 0
+    ? `+${numberBonus}`
+    : numberBonus < 0
+    ? `${numberBonus}`
+    : "0";
 };
 
 /**

--- a/src/mediawiki/templates/InfoboxItem/InfoboxItem.test.ts
+++ b/src/mediawiki/templates/InfoboxItem/InfoboxItem.test.ts
@@ -1,7 +1,7 @@
 import InfoboxItem from "./InfoboxItem";
 
 import { NO_ALCHABLE_PARAM } from "@/types/params";
-import { Item, ItemID, Params, WearPos } from "@/utils/cache2";
+import { EntityOps, Item, ItemID, Params, WearPos } from "@/utils/cache2";
 
 const BASE_ITEM: Item = {
   name: "Test Item",
@@ -27,8 +27,8 @@ const BASE_ITEM: Item = {
   femaleModel: undefined,
   femaleOffset: 0,
   femaleModel1: undefined,
-  groundActions: [],
-  inventoryActions: ["Test Action"],
+  groundOps: new EntityOps(),
+  inventoryOps: ["Test Action"],
   subops: [],
   recolorFrom: [],
   recolorTo: [],
@@ -39,8 +39,8 @@ const BASE_ITEM: Item = {
   femaleModel2: undefined,
   maleChatheadModel: undefined,
   femaleChatheadModel: undefined,
-  maleChatheadModel2: undefined,
-  femaleChatheadModel2: undefined,
+  maleChatheadModel1: undefined,
+  femaleChatheadModel1: undefined,
   category: undefined,
   zan2d: 0,
   noteLinkedItem: undefined,

--- a/src/mediawiki/templates/InfoboxItem/InfoboxItem.utils.test.ts
+++ b/src/mediawiki/templates/InfoboxItem/InfoboxItem.utils.test.ts
@@ -4,7 +4,7 @@ describe("InfoboxItem utils", () => {
   test("getInventoryActions - no sub ops", () => {
     expect(
       getInventoryActions({
-        inventoryActions: ["Test Action"],
+        inventoryOps: ["Test Action"],
         subops: [],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)
@@ -14,7 +14,7 @@ describe("InfoboxItem utils", () => {
   test("getInventoryActions - multiple actions", () => {
     expect(
       getInventoryActions({
-        inventoryActions: ["Test Action", null, undefined, " Test Action 2"],
+        inventoryOps: ["Test Action", null, undefined, " Test Action 2"],
         subops: [],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)
@@ -24,7 +24,7 @@ describe("InfoboxItem utils", () => {
   test("getInventoryActions - with sub ops", () => {
     expect(
       getInventoryActions({
-        inventoryActions: ["Test Action 1", "Test Action 2", "Test Action 3"],
+        inventoryOps: ["Test Action 1", "Test Action 2", "Test Action 3"],
         subops: [["Sub Action 1"], ["Sub Action 2.1", "Sub Action 2.2"], []],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)

--- a/src/mediawiki/templates/InfoboxItem/InfoboxItem.utils.ts
+++ b/src/mediawiki/templates/InfoboxItem/InfoboxItem.utils.ts
@@ -8,10 +8,10 @@ import { Item } from "@/utils/cache2";
  * @returns An array of inventory actions, possibly with sub-operations included.
  */
 export const getInventoryActions = (item: Item) => {
-  if (!item.inventoryActions) {
+  if (!item.inventoryOps) {
     return [];
   }
-  return item.inventoryActions
+  return item.inventoryOps
     .map((action, index) => {
       const subops = item.subops?.[index];
       return subops?.length > 0

--- a/src/mediawiki/templates/InfoboxNpc/InfoboxNpc.test.ts
+++ b/src/mediawiki/templates/InfoboxNpc/InfoboxNpc.test.ts
@@ -1,18 +1,28 @@
 import InfoboxNpcTemplate from "./InfoboxNpc";
 
-import { NPCID, Params, NPC } from "@/utils/cache2";
+import { EntityOps, NPCID, Params, NPC } from "@/utils/cache2";
 
 // Helper function to create mock NPCs for testing
-const createMockNpc = (name: string, id: number, combatLevel = 0, examineText = ""): NPC => ({
-  name,
-  id: id as NPCID,
-  combatLevel,
-  size: 1,
-  actions: ["Talk-to", "Examine"],
-  params: new Params(),
-  examine: examineText,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any);
+const createMockNpc = (
+  name: string,
+  id: number,
+  combatLevel = 0,
+  examineText = ""
+): NPC =>
+  ({
+    name,
+    id: id as NPCID,
+    combatLevel,
+    size: 1,
+    actions: ["Talk-to", "Examine"],
+    ops: new EntityOps([
+      [0, { text: "Talk-to" }],
+      [1, { text: "Examine" }],
+    ]),
+    params: new Params(),
+    examine: examineText,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
 
 describe("InfoboxNpcTemplate", () => {
   it("should strip HTML tags from NPC name", () => {
@@ -51,9 +61,24 @@ describe("InfoboxNpcTemplate", () => {
 
   describe("multi-version functionality", () => {
     it("should generate versioned template for multiple NPCs with same name", () => {
-      const npc1 = createMockNpc("Guard", 1001, 21, "He tries to keep order around here.");
-      const npc2 = createMockNpc("Guard", 1002, 21, "She tries to keep order around here.");
-      const npc3 = createMockNpc("Guard", 1003, 25, "Another guard with different combat level.");
+      const npc1 = createMockNpc(
+        "Guard",
+        1001,
+        21,
+        "He tries to keep order around here."
+      );
+      const npc2 = createMockNpc(
+        "Guard",
+        1002,
+        21,
+        "She tries to keep order around here."
+      );
+      const npc3 = createMockNpc(
+        "Guard",
+        1003,
+        25,
+        "Another guard with different combat level."
+      );
 
       const template = InfoboxNpcTemplate([npc1, npc2, npc3]);
       const built = template.build();
@@ -61,40 +86,48 @@ describe("InfoboxNpcTemplate", () => {
       expect(built).toMatchSnapshot();
 
       const templateParams = built.params || [];
-      
+
       // Check version parameters
-      expect(templateParams.find(p => p.key === "version1")?.value).toBe("1");
-      expect(templateParams.find(p => p.key === "version2")?.value).toBe("2");
-      expect(templateParams.find(p => p.key === "version3")?.value).toBe("3");
+      expect(templateParams.find((p) => p.key === "version1")?.value).toBe("1");
+      expect(templateParams.find((p) => p.key === "version2")?.value).toBe("2");
+      expect(templateParams.find((p) => p.key === "version3")?.value).toBe("3");
 
       // Check shared parameters (same values across all NPCs)
-      expect(templateParams.find(p => p.key === "name")?.value).toBe("Guard");
+      expect(templateParams.find((p) => p.key === "name")?.value).toBe("Guard");
 
       // Check numbered parameters (different values)
-      expect(templateParams.find(p => p.key === "id1")?.value).toBe("1001");
-      expect(templateParams.find(p => p.key === "id2")?.value).toBe("1002");
-      expect(templateParams.find(p => p.key === "id3")?.value).toBe("1003");
+      expect(templateParams.find((p) => p.key === "id1")?.value).toBe("1001");
+      expect(templateParams.find((p) => p.key === "id2")?.value).toBe("1002");
+      expect(templateParams.find((p) => p.key === "id3")?.value).toBe("1003");
 
       // Check image naming convention
-      expect(templateParams.find(p => p.key === "image1")?.value).toContain("Guard.png");
-      expect(templateParams.find(p => p.key === "image2")?.value).toContain("Guard (2).png");
-      expect(templateParams.find(p => p.key === "image3")?.value).toContain("Guard (3).png");
+      expect(templateParams.find((p) => p.key === "image1")?.value).toContain(
+        "Guard.png"
+      );
+      expect(templateParams.find((p) => p.key === "image2")?.value).toContain(
+        "Guard (2).png"
+      );
+      expect(templateParams.find((p) => p.key === "image3")?.value).toContain(
+        "Guard (3).png"
+      );
     });
 
     it("should handle array with single NPC", () => {
       const npc = createMockNpc("Single Guard", 2001, 30);
-      
+
       const template = InfoboxNpcTemplate([npc]);
       const built = template.build();
 
       expect(built).toMatchSnapshot();
 
       const templateParams = built.params || [];
-      
+
       // Single NPC in array should use single NPC behavior (no versioned parameters)
-      expect(templateParams.find(p => p.key === "version1")).toBeUndefined();
-      expect(templateParams.find(p => p.key === "name")?.value).toBe("Single Guard");
-      expect(templateParams.find(p => p.key === "id")?.value).toBe("2001");
+      expect(templateParams.find((p) => p.key === "version1")).toBeUndefined();
+      expect(templateParams.find((p) => p.key === "name")?.value).toBe(
+        "Single Guard"
+      );
+      expect(templateParams.find((p) => p.key === "id")?.value).toBe("2001");
     });
 
     it("should handle multiple NPCs with HTML tags in names", () => {
@@ -107,14 +140,22 @@ describe("InfoboxNpcTemplate", () => {
       expect(built).toMatchSnapshot();
 
       const templateParams = built.params || [];
-      
+
       // Names are different after stripping HTML, so they should be numbered
-      expect(templateParams.find(p => p.key === "name1")?.value).toBe("Red Guard");
-      expect(templateParams.find(p => p.key === "name2")?.value).toBe("Blue Guard");
+      expect(templateParams.find((p) => p.key === "name1")?.value).toBe(
+        "Red Guard"
+      );
+      expect(templateParams.find((p) => p.key === "name2")?.value).toBe(
+        "Blue Guard"
+      );
 
       // Verify image filenames are cleaned
-      expect(templateParams.find(p => p.key === "image1")?.value).toContain("Red Guard.png");
-      expect(templateParams.find(p => p.key === "image2")?.value).toContain("Blue Guard (2).png");
+      expect(templateParams.find((p) => p.key === "image1")?.value).toContain(
+        "Red Guard.png"
+      );
+      expect(templateParams.find((p) => p.key === "image2")?.value).toContain(
+        "Blue Guard (2).png"
+      );
     });
 
     it("should handle empty array", () => {

--- a/src/mediawiki/templates/InfoboxNpc/InfoboxNpc.ts
+++ b/src/mediawiki/templates/InfoboxNpc/InfoboxNpc.ts
@@ -12,7 +12,7 @@ import { stripHtmlTags } from "@/utils/string";
  */
 const createInfoboxNpcData = (npc: NPC, index = 0): InfoboxNpc => {
   const cleanName = stripHtmlTags(npc.name);
-  
+
   return {
     name: cleanName,
     image: new MediaWikiFile(
@@ -30,7 +30,11 @@ const createInfoboxNpcData = (npc: NPC, index = 0): InfoboxNpc => {
     race: "[[Human]]",
     location: "",
     gender: "Male",
-    options: npc.actions.filter((action) => action && action !== "null"),
+    options: [...npc.ops.values()]
+      .map((op) => op.text)
+      .filter(
+        (action): action is string => action != null && action !== "null"
+      ),
     map: "No",
     examine: Context.examines?.npcs ? Context.examines.npcs[npc.id] : "",
     id: `${Context.beta ? "beta" : ""}${npc.id.toString()}`,

--- a/src/mediawiki/templates/InfoboxScenery/InfoboxScenery.test.ts
+++ b/src/mediawiki/templates/InfoboxScenery/InfoboxScenery.test.ts
@@ -1,6 +1,6 @@
 import InfoboxSceneryTemplate from "./InfoboxScenery";
 
-import { Obj, ObjID, Params } from "@/utils/cache2";
+import { EntityOps, Obj, ObjID, Params } from "@/utils/cache2";
 
 // Helper function to create mock scenery objects for testing
 const createMockScenery = (
@@ -12,6 +12,9 @@ const createMockScenery = (
     name,
     id: id as ObjID,
     actions,
+    ops: new EntityOps(
+      actions.map((a, i) => [i, { text: a }] as [number, { text: string }])
+    ),
     params: new Params(),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any);

--- a/src/mediawiki/templates/InfoboxScenery/InfoboxScenery.ts
+++ b/src/mediawiki/templates/InfoboxScenery/InfoboxScenery.ts
@@ -27,7 +27,9 @@ const createInfoboxSceneryData = (
     quest: "No",
     location: options?.location,
     map: options?.map,
-    options: scenery.actions,
+    options: [...scenery.ops.values()]
+      .map((op) => op.text)
+      .filter((v): v is string => v != null),
     examine: Context.examines?.scenery
       ? Context.examines.scenery[scenery.id]
       : "",

--- a/src/tasks/combatAchievements/combatAchievements.utils.ts
+++ b/src/tasks/combatAchievements/combatAchievements.utils.ts
@@ -38,9 +38,9 @@ export const MONSTER_PARAM_ID = 1312;
  */
 export const getCombatAchievement = (
   struct: Struct,
-  tierMap: Map<number, string | number>,
-  typeMap: Map<number, string | number>,
-  monsterMap: Map<number, string | number>
+  tierMap: Map<number, string | number | bigint>,
+  typeMap: Map<number, string | number | bigint>,
+  monsterMap: Map<number, string | number | bigint>
 ): CombatAchievement => {
   const id = struct.params.get(CAID_PARAM_ID as ParamID) as number;
   const title = struct.params.get(TITLE_PARAM_ID as ParamID) as string;

--- a/src/tasks/differences/file/file.utils.test.ts
+++ b/src/tasks/differences/file/file.utils.test.ts
@@ -97,10 +97,10 @@ describe("file utils", () => {
           // @ts-ignore Do not require entire NPC
           {
             actions: ["Talk", null, null, null, null],
-          },
+          } as any,
           {
             actions: ["Talk", null, "Trade", null, null],
-          }
+          } as any
         )
       ).toEqual({
         actions: {
@@ -117,10 +117,10 @@ describe("file utils", () => {
           // @ts-ignore Do not require entire NPC
           {
             actions: ["Talk", null, "Trade", null, null],
-          },
+          } as any,
           {
             actions: ["Talk", null, null, null, null],
-          }
+          } as any
         )
       ).toEqual({
         actions: {
@@ -137,10 +137,10 @@ describe("file utils", () => {
           // @ts-ignore Do not require entire NPC
           {
             actions: null,
-          },
+          } as any,
           {
             actions: ["Talk", null, null, null, null],
-          }
+          } as any
         )
       ).toEqual({
         actions: {
@@ -157,10 +157,10 @@ describe("file utils", () => {
           // @ts-ignore Do not require entire NPC
           {
             actions: ["Talk", null, null, null, null],
-          },
+          } as any,
           {
             actions: null,
-          }
+          } as any
         )
       ).toEqual({
         actions: {

--- a/src/tasks/pages/types/item.test.ts
+++ b/src/tasks/pages/types/item.test.ts
@@ -5,7 +5,7 @@ import {
   flushItemPages,
 } from "./item";
 
-import { Item, ItemID } from "@/utils/cache2";
+import { EntityOps, Item, ItemID } from "@/utils/cache2";
 
 // Mock dependencies
 jest.mock("../../renders", () => ({
@@ -45,8 +45,8 @@ const createMockItem = (id: number, name: string): Item => {
     femaleModel: undefined,
     femaleOffset: 0,
     femaleModel1: undefined,
-    groundActions: [],
-    inventoryActions: [],
+    groundOps: new EntityOps(),
+    inventoryOps: [],
     subops: [],
     recolorFrom: [],
     recolorTo: [],

--- a/src/tasks/pages/types/npc.test.ts
+++ b/src/tasks/pages/types/npc.test.ts
@@ -7,7 +7,7 @@ import {
 import { writePageToFile } from "../pages.utils";
 
 import { npcPageBuilder } from "@/mediawiki/pages/npc";
-import { NPC, NPCID, Params, CacheProvider } from "@/utils/cache2";
+import { EntityOps, NPC, NPCID, Params, CacheProvider } from "@/utils/cache2";
 
 // Mock the dependencies
 jest.mock("../../renders", () => ({
@@ -51,7 +51,7 @@ describe("NPC name mapping", () => {
       name,
       id: id as NPCID,
       combatLevel,
-      actions: [],
+      ops: new EntityOps(),
       params: new Params(),
       multiChildren: multiChildren as NPCID[],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/tasks/renders/npcs.test.ts
+++ b/src/tasks/renders/npcs.test.ts
@@ -4,7 +4,7 @@ import { copyFile } from "fs/promises";
 import { renderNpcs, clearNpcNameCounts, getNpcNameCounts } from "./npcs";
 
 import Context from "@/context";
-import { CacheProvider, NPC, NPCID, Params } from "@/utils/cache2";
+import { CacheProvider, EntityOps, NPC, NPCID, Params } from "@/utils/cache2";
 import { formatFileName } from "@/utils/files";
 
 // Mock the fs functions
@@ -38,7 +38,7 @@ describe("renderNpcs multi-version functionality", () => {
       name,
       id: id as NPCID,
       combatLevel: 21,
-      actions: [],
+      ops: new EntityOps(),
       params: new Params(),
       multiChildren: multiChildren || [],
       getMultiChildren: jest.fn().mockResolvedValue([]),

--- a/src/utils/cache2/Reader.ts
+++ b/src/utils/cache2/Reader.ts
@@ -1,5 +1,5 @@
 import { CacheVersion } from "./Cache";
-import { ItemID, KitID, KitOrItem, ParamID, Params } from "./types";
+import { ItemID, KitID, KitOrItem, ModelID, ParamID, Params } from "./types";
 
 export const cp1252CharMap: string[] = (() => {
   const ext = "€?‚ƒ„…†‡ˆ‰Š‹Œ?Ž??‘’“”•–—˜™š›œ?žŸ";
@@ -174,6 +174,9 @@ export class Reader {
         case 1:
           out.set(param as ParamID, this.string());
           break;
+        case 2:
+          out.set(param as ParamID, this.i64());
+          break;
         default:
           throw new Error(`invalid type in param table ${type}`);
       }
@@ -192,6 +195,9 @@ export class Reader {
     } else {
       throw new Error(`invalid KitOrItem ${id}`);
     }
+  }
+  public model(): ModelID {
+    return this.i32() as ModelID;
   }
   public u32o16(): number {
     // rl BigSmart

--- a/src/utils/cache2/loaders/EntityOps.ts
+++ b/src/utils/cache2/loaders/EntityOps.ts
@@ -1,0 +1,78 @@
+import { Reader } from "../Reader";
+import { VarbitID, VarPID } from "../types";
+
+export interface EntityOp {
+  text: string | null;
+  conditionals?: ConditionalOp[];
+  subs?: EntityOps;
+}
+
+export interface ConditionalOp {
+  text: string;
+
+  varp?: VarPID;
+  varbit?: VarbitID;
+
+  min: number;
+  max: number;
+}
+
+export class EntityOps extends Map<number, EntityOp> {
+  public decodeOp(r: Reader, opID: number): void {
+    const op = this.getOrCreate(opID);
+    op.text = r.stringNullHidden();
+  }
+
+  public decodeSubOp(r: Reader): void {
+    const op = this.getOrCreate(r.u8(), r.u8());
+    op.text = r.string();
+  }
+
+  public decodeConditionalOp(r: Reader): void {
+    const op = this.getOrCreate(r.u8());
+    const varp = r.u16();
+    const varbit = r.u16();
+    const cop: ConditionalOp = {
+      min: r.i32(),
+      max: r.i32(),
+      text: r.string(),
+    };
+    if (varp != 0xffff) {
+      cop.varp = varp as VarPID;
+    }
+    if (varbit != 0xffff) {
+      cop.varbit = varbit as VarbitID;
+    }
+    (op.conditionals ??= []).push(cop);
+  }
+
+  public decodeConditionalSubOp(r: Reader): void {
+    const op = this.getOrCreate(r.u8(), r.u16());
+    const varp = r.u16();
+    const varbit = r.u16();
+    const cop: ConditionalOp = {
+      min: r.i32(),
+      max: r.i32(),
+      text: r.string(),
+    };
+    if (varp != 0xffff) {
+      cop.varp = varp as VarPID;
+    }
+    if (varbit != 0xffff) {
+      cop.varbit = varbit as VarbitID;
+    }
+    (op.conditionals ??= []).push(cop);
+  }
+
+  public getOrCreate(index: number, subIndex?: number): EntityOp {
+    let v = this.get(index);
+    if (!v) {
+      v = {} as EntityOp;
+      this.set(index, v);
+    }
+    if (subIndex == null) {
+      return v;
+    }
+    return (v.subs ??= new EntityOps()).getOrCreate(subIndex);
+  }
+}

--- a/src/utils/cache2/loaders/Enum.ts
+++ b/src/utils/cache2/loaders/Enum.ts
@@ -5,7 +5,7 @@ import { EnumID, ScriptVarChar } from "../types";
 
 export class EnumValueMap<
   K extends number = number,
-  V extends string | number = string | number
+  V extends string | number | bigint = string | number | bigint
 > extends Map<K, V> {
   constructor(readonly parent: Enum<K, V>) {
     super();
@@ -15,7 +15,7 @@ export class EnumValueMap<
 @Typed
 export class Enum<
   K extends number = number,
-  V extends string | number = string | number
+  V extends string | number | bigint = string | number | bigint
 > extends PerFileLoadable {
   constructor(public id: EnumID) {
     super();
@@ -36,6 +36,12 @@ export class Enum<
 
   public static decode(reader: Reader, id: EnumID): Enum {
     const v = new Enum(id);
+    function readTable(coder: "i32" | "i64" | "string") {
+      const size = reader.u16();
+      for (let i = 0; i < size; i++) {
+        v.map.set(reader.i32(), reader[coder]());
+      }
+    }
     for (let opcode: number; (opcode = reader.u8()) != 0; ) {
       switch (opcode) {
         case 1:
@@ -51,14 +57,17 @@ export class Enum<
           v.defaultValue = reader.i32();
           break;
         case 5:
-        case 6: {
-          const coder = opcode === 5 ? ("string" as const) : ("i32" as const);
-          const size = reader.u16();
-          for (let i = 0; i < size; i++) {
-            v.map.set(reader.i32(), reader[coder]());
-          }
+          readTable("string");
           break;
-        }
+        case 6:
+          readTable("i32");
+          break;
+        case 7:
+          readTable("i64");
+          break;
+        case 8:
+          v.defaultValue = reader.i64();
+          break;
         default:
           throw new Error(`unknown enum opcode ${opcode}`);
       }

--- a/src/utils/cache2/loaders/Item.ts
+++ b/src/utils/cache2/loaders/Item.ts
@@ -198,14 +198,14 @@ export class Item extends PerFileLoadable {
           v.maleModel1 = r.model();
           break;
         case 47:
+          v.maleModel2 = r.model();
+          break;
+        case 48:
           v.femaleModel = r.model();
           v.femaleOffset = r.u8();
           break;
-        case 48:
-          v.femaleModel1 = r.model();
-          break;
         case 49:
-          v.maleModel2 = r.model();
+          v.femaleModel1 = r.model();
           break;
         case 50:
           v.femaleModel2 = r.model();
@@ -214,10 +214,10 @@ export class Item extends PerFileLoadable {
           v.maleChatheadModel = r.model();
           break;
         case 52:
-          v.femaleChatheadModel = r.model();
+          v.maleChatheadModel1 = r.model();
           break;
         case 53:
-          v.maleChatheadModel1 = r.model();
+          v.femaleChatheadModel = r.model();
           break;
         case 54:
           v.femaleChatheadModel1 = r.model();

--- a/src/utils/cache2/loaders/Item.ts
+++ b/src/utils/cache2/loaders/Item.ts
@@ -1,3 +1,4 @@
+import { EntityOps } from "./EntityOps";
 import { PerFileLoadable } from "../Loadable";
 import { Reader } from "../Reader";
 import { Typed } from "../reflect";
@@ -43,8 +44,8 @@ export class Item extends PerFileLoadable {
   public femaleModel = <ModelID>-1;
   public femaleOffset = 0;
   public femaleModel1 = <ModelID>-1;
-  public groundActions: (string | null)[] = [null, null, "Take", null, null];
-  public inventoryActions: (string | null)[] = [null, null, null, null, "Drop"];
+  public groundOps = new EntityOps();
+  public inventoryOps: (string | null)[] = [null, null, null, null, "Drop"];
   public subops: string[][] = [];
   public recolorFrom: HSL[] = <HSL[]>[];
   public recolorTo: HSL[] = <HSL[]>[];
@@ -56,8 +57,8 @@ export class Item extends PerFileLoadable {
   public femaleModel2 = <ModelID>-1;
   public maleChatheadModel = <ModelID>-1;
   public femaleChatheadModel = <ModelID>-1;
-  public maleChatheadModel2 = <ModelID>-1;
-  public femaleChatheadModel2 = <ModelID>-1;
+  public maleChatheadModel1 = <ModelID>-1;
+  public femaleChatheadModel1 = <ModelID>-1;
   public category = <CategoryID>-1;
   public zan2d = 0;
   public noteLinkedItem = <ItemID>-1;
@@ -142,14 +143,14 @@ export class Item extends PerFileLoadable {
         case 32:
         case 33:
         case 34:
-          v.groundActions[opcode - 30] = r.stringNullHidden();
+          v.groundOps.decodeOp(r, opcode - 30);
           break;
         case 35:
         case 36:
         case 37:
         case 38:
         case 39:
-          v.inventoryActions[opcode - 35] = r.string();
+          v.inventoryOps[opcode - 35] = r.string();
           break;
         case 40: {
           const len = r.u8();
@@ -186,6 +187,41 @@ export class Item extends PerFileLoadable {
           }
           break;
         }
+        case 44:
+          v.inventoryModel = r.model();
+          break;
+        case 45:
+          v.maleModel = r.model();
+          v.maleOffset = r.u8();
+          break;
+        case 46:
+          v.maleModel1 = r.model();
+          break;
+        case 47:
+          v.femaleModel = r.model();
+          v.femaleOffset = r.u8();
+          break;
+        case 48:
+          v.femaleModel1 = r.model();
+          break;
+        case 49:
+          v.maleModel2 = r.model();
+          break;
+        case 50:
+          v.femaleModel2 = r.model();
+          break;
+        case 51:
+          v.maleChatheadModel = r.model();
+          break;
+        case 52:
+          v.femaleChatheadModel = r.model();
+          break;
+        case 53:
+          v.maleChatheadModel1 = r.model();
+          break;
+        case 54:
+          v.femaleChatheadModel1 = r.model();
+          break;
         case 65:
           v.isGrandExchangable = true;
           break;
@@ -205,10 +241,10 @@ export class Item extends PerFileLoadable {
           v.femaleChatheadModel = <ModelID>r.u16();
           break;
         case 92:
-          v.maleChatheadModel2 = <ModelID>r.u16();
+          v.maleChatheadModel1 = <ModelID>r.u16();
           break;
         case 93:
-          v.femaleChatheadModel2 = <ModelID>r.u16();
+          v.femaleChatheadModel1 = <ModelID>r.u16();
           break;
         case 94:
           v.category = <CategoryID>r.u16();
@@ -267,6 +303,15 @@ export class Item extends PerFileLoadable {
           break;
         case 249:
           v.params = r.params();
+          break;
+        case 200:
+          v.groundOps.decodeSubOp(r);
+          break;
+        case 201:
+          v.groundOps.decodeConditionalOp(r);
+          break;
+        case 202:
+          v.groundOps.decodeConditionalSubOp(r);
           break;
         default:
           throw new Error(`unknown opcode ${opcode}`);

--- a/src/utils/cache2/loaders/NPC.ts
+++ b/src/utils/cache2/loaders/NPC.ts
@@ -15,6 +15,7 @@ import {
   VarbitID,
   VarPID,
 } from "../types";
+import { EntityOps } from "./EntityOps";
 
 @Typed
 export class NPC extends MultiChildrenEntity<NPC, NPCID> {
@@ -83,7 +84,7 @@ export class NPC extends MultiChildrenEntity<NPC, NPCID> {
   public rotateLeftAnimation = <AnimationID>-1;
   public rotateRightAnimation = <AnimationID>-1;
   public category = <CategoryID>-1;
-  public actions: (string | null)[] = [null, null, null, null, null];
+  public ops = new EntityOps();
   public recolorFrom: HSL[] = <HSL[]>[];
   public recolorTo: HSL[] = <HSL[]>[];
   public retextureFrom: TextureID[] = <TextureID[]>[];
@@ -175,7 +176,7 @@ export class NPC extends MultiChildrenEntity<NPC, NPCID> {
         case 32:
         case 33:
         case 34:
-          v.actions[opcode - 30] = r.stringNullHidden();
+          v.ops.decodeOp(r, opcode - 30);
           break;
         case 40: {
           const len = r.u8();
@@ -202,6 +203,22 @@ export class NPC extends MultiChildrenEntity<NPC, NPCID> {
           v.chatheadModels = new Array(len);
           for (let i = 0; i < len; i++) {
             v.chatheadModels[i] = <ModelID>r.u16();
+          }
+          break;
+        }
+        case 61: {
+          const len = r.u8();
+          v.models = new Array(len);
+          for (let i = 0; i < len; i++) {
+            v.models[i] = r.model();
+          }
+          break;
+        }
+        case 62: {
+          const len = r.u8();
+          v.chatheadModels = new Array(len);
+          for (let i = 0; i < len; i++) {
+            v.chatheadModels[i] = r.model();
           }
           break;
         }
@@ -345,6 +362,15 @@ export class NPC extends MultiChildrenEntity<NPC, NPCID> {
           break;
         case 249:
           v.params = r.params();
+          break;
+        case 251:
+          v.ops.decodeSubOp(r);
+          break;
+        case 252:
+          v.ops.decodeConditionalOp(r);
+          break;
+        case 253:
+          v.ops.decodeConditionalSubOp(r);
           break;
         default:
           throw new Error(`unknown opcode ${opcode}`);

--- a/src/utils/cache2/loaders/Obj.ts
+++ b/src/utils/cache2/loaders/Obj.ts
@@ -1,3 +1,4 @@
+import { EntityOps } from "./EntityOps";
 import type { CacheProvider } from "../Cache";
 import { MultiChildrenEntity } from "../MultiChildrenEntity";
 import { Reader } from "../Reader";
@@ -53,7 +54,7 @@ export class Obj extends MultiChildrenEntity<Obj, ObjID> {
   public ambient = 0;
   public contrast = 0;
   public category = <CategoryID>-1;
-  public actions: (string | null)[] = [null, null, null, null, null];
+  public ops = new EntityOps();
   public recolorFrom: HSL[] = <HSL[]>[];
   public recolorTo: HSL[] = <HSL[]>[];
   public retextureFrom: TextureID[] = <TextureID[]>[];
@@ -112,6 +113,18 @@ export class Obj extends MultiChildrenEntity<Obj, ObjID> {
           }
           break;
         }
+        case 6:
+        case 7: {
+          const len = r.u8();
+          v.models = new Array(len);
+          v.modelShapes = new Array(len);
+          for (let i = 0; i < len; i++) {
+            v.models[i] = r.model();
+            v.modelShapes[i] =
+              opcode == 7 ? ObjShape.CentrepieceStraight : <ObjShape>r.u8();
+          }
+          break;
+        }
         case 2:
           v.name = r.string();
           break;
@@ -160,7 +173,7 @@ export class Obj extends MultiChildrenEntity<Obj, ObjID> {
         case 32:
         case 33:
         case 34:
-          v.actions[opcode - 30] = r.stringNullHidden();
+          v.ops.decodeOp(r, opcode - 30);
           break;
         case 40: {
           const len = r.u8();
@@ -296,6 +309,15 @@ export class Obj extends MultiChildrenEntity<Obj, ObjID> {
         case 249:
           v.params = r.params();
           break;
+        case 100:
+          v.ops.decodeSubOp(r);
+          break;
+        case 101:
+          v.ops.decodeConditionalOp(r);
+          break;
+        case 102:
+          v.ops.decodeConditionalSubOp(r);
+          break;
         default:
           throw new Error(`unknown opcode ${opcode}`);
       }
@@ -305,7 +327,7 @@ export class Obj extends MultiChildrenEntity<Obj, ObjID> {
       v.isDoor = 0;
       if (
         v.modelShapes?.[0] === ObjShape.CentrepieceStraight ||
-        v.actions.some((a) => a !== null)
+        [...v.ops.values()].some((a) => a.text != null)
       ) {
         v.isDoor = 1;
       }

--- a/src/utils/cache2/loaders/Param.ts
+++ b/src/utils/cache2/loaders/Param.ts
@@ -1,7 +1,8 @@
 import { PerFileLoadable } from "../Loadable";
 import { Reader } from "../Reader";
 import { Typed } from "../reflect";
-import { ParamID, ScriptVarChar } from "../types";
+import { ScriptVarType } from "../ScriptVarType";
+import { ParamID, ScriptVarChar, ScriptVarID } from "../types";
 
 @Typed
 export class Param extends PerFileLoadable {
@@ -12,17 +13,26 @@ export class Param extends PerFileLoadable {
   public static readonly index = 2;
   public static readonly archive = 11;
 
-  public type = <ScriptVarChar>0;
+  public typeChar = <ScriptVarChar>0;
+  public typeID: ScriptVarID | undefined;
   public isMembers = true;
   public defaultInt = 0;
+  public defaultLong = 0n;
   public defaultString: string | null = null;
+
+  public get type(): ScriptVarType | undefined {
+    if (this.typeID !== undefined) {
+      return ScriptVarType.forID(this.typeID);
+    }
+    return ScriptVarType.forChar(this.typeChar);
+  }
 
   public static decode(r: Reader, id: ParamID): Param {
     const v = new Param(id);
     for (let opcode: number; (opcode = r.u8()) != 0; ) {
       switch (opcode) {
         case 1:
-          v.type = <ScriptVarChar>r.u8();
+          v.typeChar = <ScriptVarChar>r.u8();
           break;
         case 2:
           v.defaultInt = r.i32();
@@ -32,6 +42,12 @@ export class Param extends PerFileLoadable {
           break;
         case 5:
           v.defaultString = r.string();
+          break;
+        case 7:
+          v.defaultLong = r.i64();
+          break;
+        case 8:
+          v.typeID = r.u8() as ScriptVarID;
           break;
         default:
           throw new Error(`unknown opcode ${opcode}`);

--- a/src/utils/cache2/loaders/SpotAnim.ts
+++ b/src/utils/cache2/loaders/SpotAnim.ts
@@ -37,6 +37,9 @@ export class SpotAnim extends PerFileLoadable {
         case 2:
           v.animationId = r.u16();
           break;
+        case 3:
+          v.modelId = r.model();
+          break;
         case 4:
           v.resizeX = r.u16();
           break;

--- a/src/utils/cache2/loaders/Widget.ts
+++ b/src/utils/cache2/loaders/Widget.ts
@@ -458,15 +458,8 @@ export class Widget extends PerArchiveParentLoadable {
 
   private decodeModelWidget(r: Reader): void {
     this.modelType = 1;
-    this.modelId = <ModelID>r.u16();
-    if (this.modelId === 0xffff) {
-      this.modelId = <ModelID>-1;
-    }
-
-    this.alternateModelId = <ModelID>r.u16();
-    if (this.alternateModelId === 0xffff) {
-      this.alternateModelId = <ModelID>-1;
-    }
+    this.modelId = r.model();
+    this.alternateModelId = r.model();
 
     this.animation = <AnimationID>r.u16();
     if (this.animation === 0xffff) {
@@ -680,10 +673,7 @@ export class Widget extends PerArchiveParentLoadable {
 
       case 6: // Model
         this.modelType = 1;
-        this.modelId = <ModelID>r.u16();
-        if (this.modelId === 0xffff) {
-          this.modelId = <ModelID>-1;
-        }
+        this.modelId = r.model();
         this.offsetX2d = r.i16();
         this.offsetY2d = r.i16();
         this.rotationX = r.u16();

--- a/src/utils/cache2/loaders/index.ts
+++ b/src/utils/cache2/loaders/index.ts
@@ -2,6 +2,7 @@ export * from "./Animation";
 export * from "./Area";
 export * from "./ClientScript";
 export * from "./DBRow";
+export * from "./EntityOps";
 export * from "./Enum";
 export * from "./GameVal";
 export * from "./HealthBar";

--- a/src/utils/cache2/types.ts
+++ b/src/utils/cache2/types.ts
@@ -99,7 +99,7 @@ export type OverlayPath = NewType<number, "OverlayPath">;
 export type OverlayRotation = NewType<number, "OverlayRotation">;
 export type TileSettings = NewType<number, "TileSettings">;
 
-export class Params extends Map<ParamID, string | number> {}
+export class Params extends Map<ParamID, string | number | bigint> {}
 
 export type KitOrItem = { kit: KitID } | { item: ItemID } | undefined;
 


### PR DESCRIPTION
**Description**
This pull request refactors how entity actions (such as for NPCs, objects, and items) are represented and accessed throughout the codebase. The main change is the replacement of simple action arrays (e.g., `actions`, `inventoryActions`, `groundActions`) with a new `EntityOps` structure (`ops`, `inventoryOps`, `groundOps`). This provides a more consistent and extensible way to handle entity operations. The change is applied across type definitions, test files, and builder logic.

**Entity operation representation refactor:**

* Replaced all usage of `actions`, `inventoryActions`, and `groundActions` arrays with the new `EntityOps` structure (`ops`, `inventoryOps`, `groundOps`) in type definitions and test mocks for items, NPCs, and scenery. This standardizes how entity operations are accessed and manipulated. [[1]](diffhunk://#diff-40fcf094ff93ceadd73c5512bf58e0fe64cb6aab608e3b9270e74bf6c4bfe80cL98-R98) [[2]](diffhunk://#diff-40fcf094ff93ceadd73c5512bf58e0fe64cb6aab608e3b9270e74bf6c4bfe80cL120-R120) [[3]](diffhunk://#diff-40fcf094ff93ceadd73c5512bf58e0fe64cb6aab608e3b9270e74bf6c4bfe80cL137-R137) [[4]](diffhunk://#diff-fa93ac77f8ae3fc6d7412b8084e201cdee6ec0b45d6a11e0d6c7ad2ceb295961L46-R54) [[5]](diffhunk://#diff-fa93ac77f8ae3fc6d7412b8084e201cdee6ec0b45d6a11e0d6c7ad2ceb295961L119-R126) [[6]](diffhunk://#diff-519dc6b738cc74ae7dfc18798d18171611c8e6d0eaf2100eeb7f352cc882323cR40-R43) [[7]](diffhunk://#diff-519dc6b738cc74ae7dfc18798d18171611c8e6d0eaf2100eeb7f352cc882323cL56-R63) [[8]](diffhunk://#diff-519dc6b738cc74ae7dfc18798d18171611c8e6d0eaf2100eeb7f352cc882323cL69-R79) [[9]](diffhunk://#diff-519dc6b738cc74ae7dfc18798d18171611c8e6d0eaf2100eeb7f352cc882323cL91-R104) [[10]](diffhunk://#diff-519dc6b738cc74ae7dfc18798d18171611c8e6d0eaf2100eeb7f352cc882323cL106-R119) [[11]](diffhunk://#diff-519dc6b738cc74ae7dfc18798d18171611c8e6d0eaf2100eeb7f352cc882323cL119-R135) [[12]](diffhunk://#diff-519dc6b738cc74ae7dfc18798d18171611c8e6d0eaf2100eeb7f352cc882323cL132-R151) [[13]](diffhunk://#diff-519dc6b738cc74ae7dfc18798d18171611c8e6d0eaf2100eeb7f352cc882323cL145-R167) [[14]](diffhunk://#diff-4ee2952ed6645e6dd55c2981caf9bf7e8969f0f8cee8bc7174f27456a9a4120aL37-R40) [[15]](diffhunk://#diff-4ee2952ed6645e6dd55c2981caf9bf7e8969f0f8cee8bc7174f27456a9a4120aL51-R57) [[16]](diffhunk://#diff-4ee2952ed6645e6dd55c2981caf9bf7e8969f0f8cee8bc7174f27456a9a4120aL64-R73) [[17]](diffhunk://#diff-4ee2952ed6645e6dd55c2981caf9bf7e8969f0f8cee8bc7174f27456a9a4120aL88-R97) [[18]](diffhunk://#diff-4ee2952ed6645e6dd55c2981caf9bf7e8969f0f8cee8bc7174f27456a9a4120aL155-R164) [[19]](diffhunk://#diff-4ee2952ed6645e6dd55c2981caf9bf7e8969f0f8cee8bc7174f27456a9a4120aL176-R185) [[20]](diffhunk://#diff-4ee2952ed6645e6dd55c2981caf9bf7e8969f0f8cee8bc7174f27456a9a4120aL199-R208) [[21]](diffhunk://#diff-4ee2952ed6645e6dd55c2981caf9bf7e8969f0f8cee8bc7174f27456a9a4120aL224-R233) [[22]](diffhunk://#diff-4ee2952ed6645e6dd55c2981caf9bf7e8969f0f8cee8bc7174f27456a9a4120aL289-R298) [[23]](diffhunk://#diff-e708678f5e4702d59d6f67918281a9bf4510e3e954f815b8a2540cb1a921ea0bL48-R49) [[24]](diffhunk://#diff-20649b447c4ac3d3518ba09392de61cb52af2eacad2207fa870b48e96515a111L32-R33)

**Type and field updates:**

* Updated the `indexNameMap` and related type definitions to use the new field names (`ops`, `inventoryOps`, etc.) and replaced or renamed other fields for clarity and consistency (e.g., `typeChar` instead of `type`). [[1]](diffhunk://#diff-40fcf094ff93ceadd73c5512bf58e0fe64cb6aab608e3b9270e74bf6c4bfe80cL98-R98) [[2]](diffhunk://#diff-40fcf094ff93ceadd73c5512bf58e0fe64cb6aab608e3b9270e74bf6c4bfe80cL120-R120) [[3]](diffhunk://#diff-40fcf094ff93ceadd73c5512bf58e0fe64cb6aab608e3b9270e74bf6c4bfe80cL137-R137) [[4]](diffhunk://#diff-40fcf094ff93ceadd73c5512bf58e0fe64cb6aab608e3b9270e74bf6c4bfe80cL152-R152)

**Test and mock data adjustments:**

* Updated all relevant test files and mock data to use the new `EntityOps` structure and updated field names, ensuring tests reflect the new data model. [[1]](diffhunk://#diff-fa93ac77f8ae3fc6d7412b8084e201cdee6ec0b45d6a11e0d6c7ad2ceb295961L46-R54) [[2]](diffhunk://#diff-fa93ac77f8ae3fc6d7412b8084e201cdee6ec0b45d6a11e0d6c7ad2ceb295961L119-R126) [[3]](diffhunk://#diff-519dc6b738cc74ae7dfc18798d18171611c8e6d0eaf2100eeb7f352cc882323cR40-R43) [[4]](diffhunk://#diff-4ee2952ed6645e6dd55c2981caf9bf7e8969f0f8cee8bc7174f27456a9a4120aL37-R40) [[5]](diffhunk://#diff-e708678f5e4702d59d6f67918281a9bf4510e3e954f815b8a2540cb1a921ea0bL48-R49) [[6]](diffhunk://#diff-20649b447c4ac3d3518ba09392de61cb52af2eacad2207fa870b48e96515a111L32-R33)

**Builder logic improvements:**

* Refactored logic in builder files (e.g., `npcPageBuilder`) to check for dialogue options using the new `EntityOps` structure instead of the old `actions` array.

**Minor field name standardization:**

* Standardized model and chathead model field names for items to use a consistent naming convention (e.g., `maleChatheadModel1` instead of `maleChatheadModel2`). [[1]](diffhunk://#diff-fa93ac77f8ae3fc6d7412b8084e201cdee6ec0b45d6a11e0d6c7ad2ceb295961L58-R66) [[2]](diffhunk://#diff-e708678f5e4702d59d6f67918281a9bf4510e3e954f815b8a2540cb1a921ea0bL60-R61) [[3]](diffhunk://#diff-20649b447c4ac3d3518ba09392de61cb52af2eacad2207fa870b48e96515a111L44-R45)

**Checklist**

- [ ] Tests added for changes
- [ ] Changeset added
