### PR TITLE
cache238: add opcode 15

### DIFF
--- a/.changeset/eight-vans-tan.md
+++ b/.changeset/eight-vans-tan.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": minor
+---
+
+Add support for cache revision 238

--- a/src/mediawiki/pages/item/item.test.ts
+++ b/src/mediawiki/pages/item/item.test.ts
@@ -29,6 +29,7 @@ import {
 const BASE_ITEM: Item = {
   name: "Test Item",
   isMembers: true,
+  isTradeable: true,
   isGrandExchangable: true,
   id: 1234 as ItemID,
   inventoryModel: undefined,

--- a/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.test.ts
+++ b/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.test.ts
@@ -24,6 +24,7 @@ import { EntityOps, Item, ItemID, Params, WearPos } from "@/utils/cache2";
 const BASE_EQUIPABLE_ITEM: Item = {
   name: "Test Equipment",
   isMembers: true,
+  isTradeable: true,
   isGrandExchangable: true,
   id: 1234 as ItemID,
   inventoryModel: undefined,

--- a/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.utils.test.ts
+++ b/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.utils.test.ts
@@ -8,6 +8,7 @@ import { EntityOps, Item, ItemID, Params, WearPos } from "@/utils/cache2";
 const BASE_ITEM: Item = {
   name: "Test Item",
   isMembers: true,
+  isTradeable: true,
   isGrandExchangable: true,
   id: 1234 as ItemID,
   inventoryModel: undefined,

--- a/src/mediawiki/templates/InfoboxItem/InfoboxItem.test.ts
+++ b/src/mediawiki/templates/InfoboxItem/InfoboxItem.test.ts
@@ -6,6 +6,7 @@ import { EntityOps, Item, ItemID, Params, WearPos } from "@/utils/cache2";
 const BASE_ITEM: Item = {
   name: "Test Item",
   isMembers: true,
+  isTradeable: true,
   isGrandExchangable: true,
   id: 1234 as ItemID,
   inventoryModel: undefined,

--- a/src/utils/cache2/loaders/Item.ts
+++ b/src/utils/cache2/loaders/Item.ts
@@ -34,6 +34,7 @@ export class Item extends PerFileLoadable {
   public isStackable = false;
   public price = 1;
   public isMembers = false;
+  public isTradeable = true;
   public wearpos1 = <WearPos>-1;
   public wearpos2 = <WearPos>-1;
   public wearpos3 = <WearPos>-1;
@@ -118,6 +119,8 @@ export class Item extends PerFileLoadable {
         case 14:
           v.wearpos2 = <WearPos>r.u8();
           break;
+        case 15:
+          v.isTradeable = false;
         case 16:
           v.isMembers = true;
           break;


### PR DESCRIPTION
**Description**
This pull request updates the `Item` class in `src/utils/cache2/loaders/Item.ts` to add support for item tradeability. The main changes introduce a new `isTradeable` property and update the data parsing logic to handle this new attribute.

**Item tradeability support:**

* Added a new boolean property `isTradeable` to the `Item` class, defaulting to `true`.
* Updated the data parsing switch statement to set `isTradeable` to `false` when the parsed code is `15`, allowing items to be marked as untradeable.

**Checklist**

- [ ] Tests added for changes
- [ ] Changeset added
