### PR TITLE
feat: cache 239 support

### DIFF
--- a/.changeset/yummy-ghosts-cheat.md
+++ b/.changeset/yummy-ghosts-cheat.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": minor
+---
+
+Add support for cache 239

--- a/src/mediawiki/pages/item/item.test.ts
+++ b/src/mediawiki/pages/item/item.test.ts
@@ -31,6 +31,7 @@ const BASE_ITEM: Item = {
   isMembers: true,
   isTradeable: true,
   isGrandExchangable: true,
+  hasVar: false,
   id: 1234 as ItemID,
   inventoryModel: undefined,
   examine: "Examine text.",

--- a/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.test.ts
+++ b/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.test.ts
@@ -26,6 +26,7 @@ const BASE_EQUIPABLE_ITEM: Item = {
   isMembers: true,
   isTradeable: true,
   isGrandExchangable: true,
+  hasVar: false,
   id: 1234 as ItemID,
   inventoryModel: undefined,
   examine: "Test equipment.",

--- a/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.utils.test.ts
+++ b/src/mediawiki/templates/InfoboxBonuses/InfoboxBonuses.utils.test.ts
@@ -10,6 +10,7 @@ const BASE_ITEM: Item = {
   isMembers: true,
   isTradeable: true,
   isGrandExchangable: true,
+  hasVar: false,
   id: 1234 as ItemID,
   inventoryModel: undefined,
   examine: "Test item.",

--- a/src/mediawiki/templates/InfoboxItem/InfoboxItem.test.ts
+++ b/src/mediawiki/templates/InfoboxItem/InfoboxItem.test.ts
@@ -8,6 +8,7 @@ const BASE_ITEM: Item = {
   isMembers: true,
   isTradeable: true,
   isGrandExchangable: true,
+  hasVar: false,
   id: 1234 as ItemID,
   inventoryModel: undefined,
   examine: "Examine text.",

--- a/src/utils/cache2/loaders/Item.ts
+++ b/src/utils/cache2/loaders/Item.ts
@@ -32,6 +32,7 @@ export class Item extends PerFileLoadable {
   public offsetX2d = 0;
   public offsetY2d = 0;
   public isStackable = false;
+  public hasVar = false;
   public price = 1;
   public isMembers = false;
   public isTradeable = true;
@@ -303,6 +304,10 @@ export class Item extends PerFileLoadable {
           break;
         case 149:
           v.placeholderTemplate = <ItemID>r.u16();
+          break;
+        case 160:
+          v.isStackable = false;
+          v.hasVar = true;
           break;
         case 249:
           v.params = r.params();


### PR DESCRIPTION
**Description**
Add support for cache 239: add `hasVar` support to items.

See https://github.com/osrs-wiki/cache-mediawiki/actions/runs/28324146562

**Checklist**

- [x] Tests added for changes
- [x] Changeset added
