### PR TITLE
fix: correct spelling of 'ammo' in various files

### DIFF
--- a/.changeset/bumpy-humans-grab.md
+++ b/.changeset/bumpy-humans-grab.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+ammo

--- a/src/mediawiki/pages/item/__snapshots__/item.test.ts.snap
+++ b/src/mediawiki/pages/item/__snapshots__/item.test.ts.snap
@@ -323,7 +323,7 @@ exports[`Item Infobox Item infobox should not set image and altimage for Ammo we
 |rstr = 0
 |mdmg = 0
 |prayer = 0
-|slot = ammot
+|slot = ammo
 |combatstyle = Unarmed
 }}
 

--- a/src/mediawiki/templates/InfoboxBonuses/__snapshots__/InfoboxBonuses.test.ts.snap
+++ b/src/mediawiki/templates/InfoboxBonuses/__snapshots__/InfoboxBonuses.test.ts.snap
@@ -72,7 +72,7 @@ MediaWikiTemplate {
     },
     Object {
       "key": "slot",
-      "value": "ammot",
+      "value": "ammo",
     },
     Object {
       "key": "combatstyle",
@@ -452,7 +452,7 @@ MediaWikiTemplate {
     },
     Object {
       "key": "slot",
-      "value": "ammot",
+      "value": "ammo",
     },
     Object {
       "key": "combatstyle",

--- a/src/types/item/item.ts
+++ b/src/types/item/item.ts
@@ -9,7 +9,7 @@ export type WeaponSlot =
   | "hands"
   | "feet"
   | "neck"
-  | "ammot"
+  | "ammo"
   | "ring";
 
 export type WeaponType =

--- a/src/types/item/item.utils.ts
+++ b/src/types/item/item.utils.ts
@@ -9,7 +9,7 @@ const weaponSlotMap: { [key: WearPos]: WeaponSlot } = {
   [WearPos.Legs]: "legs",
   [WearPos.Shield]: "shield",
   [WearPos.Cape]: "cape",
-  [WearPos.Ammo]: "ammot",
+  [WearPos.Ammo]: "ammo",
   [WearPos.Hands]: "hands",
   [WearPos.Boots]: "feet",
   [WearPos.Amulet]: "neck",


### PR DESCRIPTION
**Description**
This pull request corrects a typo in the codebase by changing all instances of the item slot value `'ammot'` to `'ammo'`. This update ensures consistency across type definitions, utility mappings, and related tests.

Type and mapping corrections:

* Updated the `WeaponSlot` type in `item.ts` to use `'ammo'` instead of `'ammot'`.
* Updated the `weaponSlotMap` in `item.utils.ts` to map the ammo wear position to `'ammo'`.

Test and snapshot updates:

* Updated test snapshots in `item.test.ts.snap` and `InfoboxBonuses.test.ts.snap` to use `'ammo'` for the slot key. [[1]](diffhunk://#diff-50800161e85ce1eff99c0bc55d722a07596d28670d5a6930338cea9645cccf13L326-R326) [[2]](diffhunk://#diff-4b47b29e374ce725cf1a6750aa265a9228eafc6e02bf8228495906b6f3ac2410L75-R75) [[3]](diffhunk://#diff-4b47b29e374ce725cf1a6750aa265a9228eafc6e02bf8228495906b6f3ac2410L455-R455)

Changelog:

* Added a patch changelog entry for `@osrs-wiki/cache-mediawiki` describing the ammo slot correction.

**Checklist**

- [ ] Tests added for changes
- [ ] Changeset added
