### PR TITLE
feat: Add cache diff detection for boolean and bigint types

### DIFF
--- a/.changeset/tame-donkeys-smile.md
+++ b/.changeset/tame-donkeys-smile.md
@@ -1,0 +1,5 @@
+---
+"@osrs-wiki/cache-mediawiki": patch
+---
+
+Fix boolean and bigint field changes (e.g. `isStackable`) not being detected in cache differences

--- a/src/mediawiki/pages/differences/differences.utils.test.ts
+++ b/src/mediawiki/pages/differences/differences.utils.test.ts
@@ -101,6 +101,15 @@ describe("differences builder utils", () => {
       expect(formatEntryValue("count", 42)).toBe("42");
     });
 
+    test("should return value as string for boolean values", () => {
+      expect(formatEntryValue("isStackable", true)).toBe("true");
+      expect(formatEntryValue("isStackable", false)).toBe("false");
+    });
+
+    test("should return value as string for bigint values", () => {
+      expect(formatEntryValue("defaultLong", 100n)).toBe("100");
+    });
+
     test("should format objects by converting to string with custom formatting", () => {
       const objectValue = { key1: "value1", key2: 2 };
       expect(formatEntryValue("config", objectValue)).toBe(

--- a/src/mediawiki/pages/differences/differences.utils.ts
+++ b/src/mediawiki/pages/differences/differences.utils.ts
@@ -74,6 +74,8 @@ export const formatEntryValue = (field: string, value: ResultValue): string => {
       .replaceAll(",", ", ");
   } else if (typeof value === "string" || typeof value === "number") {
     return value.toString();
+  } else if (typeof value === "bigint") {
+    return value.toString();
   }
   return JSON.stringify(value)
     .replaceAll('"', "'")

--- a/src/tasks/differences/differences.ts
+++ b/src/tasks/differences/differences.ts
@@ -109,7 +109,9 @@ const differencesCache = async ({
     console.log("Generating JSON output...");
     await writeFile(
       `${dir}/${newVersion} JSON.json`,
-      JSON.stringify(cacheDifferences)
+      JSON.stringify(cacheDifferences, (_key, value) =>
+        typeof value === "bigint" ? value.toString() : value
+      )
     );
     console.log(`JSON output generated: ${newVersion} JSON.json`);
   } else if (outputFormat === "csv") {

--- a/src/tasks/differences/differences.types.ts
+++ b/src/tasks/differences/differences.types.ts
@@ -34,6 +34,7 @@ export type ResultValue =
   | string
   | number
   | boolean
+  | bigint
   | string[]
   | ItemID
   | ModelID

--- a/src/tasks/differences/file/file.utils.test.ts
+++ b/src/tasks/differences/file/file.utils.test.ts
@@ -90,6 +90,116 @@ describe("file utils", () => {
       });
     });
 
+    test("type: boolean", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            isVisible: false,
+          },
+          {
+            isVisible: true,
+          }
+        )
+      ).toEqual({
+        isVisible: {
+          oldValue: false,
+          newValue: true,
+        },
+      });
+    });
+
+    test("type: boolean (true -> false)", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            isVisible: true,
+          },
+          {
+            isVisible: false,
+          }
+        )
+      ).toEqual({
+        isVisible: {
+          oldValue: true,
+          newValue: false,
+        },
+      });
+    });
+
+    test("type: boolean (no change)", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            isVisible: true,
+          },
+          {
+            isVisible: true,
+          }
+        )
+      ).toEqual({});
+    });
+
+    test("type: bigint", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            defaultLong: 0n,
+          } as any,
+          {
+            defaultLong: 100n,
+          } as any
+        )
+      ).toEqual({
+        defaultLong: {
+          oldValue: 0n,
+          newValue: 100n,
+        },
+      });
+    });
+
+    test("type: new bigint", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            defaultLong: null,
+          } as any,
+          {
+            defaultLong: 100n,
+          } as any
+        )
+      ).toEqual({
+        defaultLong: {
+          oldValue: null,
+          newValue: 100n,
+        },
+      });
+    });
+
+    test("type: bigint (no change)", () => {
+      expect(
+        getChangedResult<NPC>(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore Do not require entire NPC
+          {
+            defaultLong: 100n,
+          } as any,
+          {
+            defaultLong: 100n,
+          } as any
+        )
+      ).toEqual({});
+    });
+
     test("type: array added elements", () => {
       expect(
         getChangedResult<NPC>(

--- a/src/tasks/differences/file/file.utils.ts
+++ b/src/tasks/differences/file/file.utils.ts
@@ -272,7 +272,11 @@ export const getChangedResult = <T extends Loadable>(
       ((typeof oldEntryValue === "string" ||
         typeof newEntryValue === "string" ||
         typeof oldEntryValue === "number" ||
-        typeof newEntryValue === "number") &&
+        typeof newEntryValue === "number" ||
+        typeof oldEntryValue === "boolean" ||
+        typeof newEntryValue === "boolean" ||
+        typeof oldEntryValue === "bigint" ||
+        typeof newEntryValue === "bigint") &&
         oldEntryValue !== newEntryValue) ||
       (isOldArray &&
         isNewArray &&


### PR DESCRIPTION
**Description**
This pull request addresses issues with detecting and handling changes to boolean and bigint fields in the cache differences logic. It ensures that changes to these field types are now correctly identified, serialized, and tested throughout the codebase.

**Improvements to cache difference detection:**

* Updated `getChangedResult` in `file.utils.ts` to properly detect changes for fields of type boolean and bigint, ensuring these differences are included in results.
* Extended the `ResultValue` type to include `bigint`, allowing these values to be handled consistently.

**Test coverage enhancements:**

* Added comprehensive tests for boolean and bigint field changes in `file.utils.test.ts`, covering cases where values change, are added, or remain unchanged.
* Added tests for formatting boolean and bigint values in `differences.utils.test.ts` to ensure correct string conversion.

**Serialization and formatting fixes:**

* Modified JSON serialization in `differences.ts` to convert bigint values to strings, preventing serialization errors.
* Updated `formatEntryValue` in `differences.utils.ts` to handle boolean and bigint values, ensuring correct output formatting.

**Documentation:**

* Added a changeset note summarizing the fix for boolean and bigint field detection in cache differences.

**Checklist**

- [x] Tests added for changes
- [x] Changeset added
